### PR TITLE
allow synchdb to capture debezium originated errors on java side

### DIFF
--- a/synchdb.h
+++ b/synchdb.h
@@ -21,7 +21,7 @@
 #include "storage/lwlock.h"
 
 /* Constants */
-#define SYNCHDB_ERRMSG_SIZE 128
+#define SYNCHDB_ERRMSG_SIZE 256
 #define SYNCHDB_MAX_DB_NAME_SIZE 64
 #define SYNCHDB_DATATYPE_NAME_SIZE 64
 #define SYNCHDB_JSON_PATH_SIZE 128


### PR DESCRIPTION
add a way for synchdb to capture errors originated from debezium connector on java side, so that the synchdb workers can report it on state view and stop the worker as necessary