### PR TITLE
significantly reduce the time needed to complete a large initial snapshot

### DIFF
--- a/dbz-engine/src/main/java/com/example/DebeziumRunner.java
+++ b/dbz-engine/src/main/java/com/example/DebeziumRunner.java
@@ -50,6 +50,7 @@ public class DebeziumRunner {
 	final int TYPE_MYSQL = 1;
 	final int TYPE_ORACLE = 2;
 	final int TYPE_SQLSERVER = 3;
+	final int BATCH_QUEUE_SIZE = 3;
 
 	/* BatchMaanger represents a Batch request queue */
 	public class BatchManager
@@ -69,7 +70,7 @@ public class DebeziumRunner {
 		}
 		public synchronized void addBatch(ChangeRecordBatch batch) throws InterruptedException
 		{
-			while (batchQueue.size() >= 5)
+			while (batchQueue.size() >= BATCH_QUEUE_SIZE)
 			{
 				wait();
 			}
@@ -194,8 +195,8 @@ public void checkMemoryStatus() {
 		props.setProperty("offset.storage.file.filename", offsetfile);
 		props.setProperty("offset.flush.interval.ms", "60000");
 		props.setProperty("schema.history.internal.store.only.captured.tables.ddl", "true");
-		props.setProperty("max.batch.size", "2048");
-		props.setProperty("max.queue.size", "4096");
+		props.setProperty("max.batch.size", "4096");
+		props.setProperty("max.queue.size", "8192");
 		props.setProperty("record.processing.order", "ORDERED");
 
 		logger.info("Hello from DebeziumRunner class!");
@@ -313,7 +314,7 @@ public void checkMemoryStatus() {
 				}
 
 				/* save this batch in active batch hash struct */
-				activeBatchHash.put(myNextBatch.batchid, myNextBatch);;
+				activeBatchHash.put(myNextBatch.batchid, myNextBatch);
 			}
 		}
 		else
@@ -400,6 +401,7 @@ public void checkMemoryStatus() {
 			myBatch.committer.markBatchFinished();
 			activeBatchHash.remove(batchid);
 		}
+		System.gc();
 	}
 	
 	public String getConnectorOffset(int connectorType, String db, String name)

--- a/replication_agent.c
+++ b/replication_agent.c
@@ -281,7 +281,6 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type)
 	ResultRelInfo *resultRelInfo;
 	ListCell * cell;
 	int i = 0;
-	MemoryContext oldContext = CurrentMemoryContext;
 
 	/*
 	 * we put in TRY and CATCH block to capture potential exceptions raised
@@ -291,9 +290,6 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type)
 	 */
 	PG_TRY();
 	{
-		StartTransactionCommand();
-		PushActiveSnapshot(GetTransactionSnapshot());
-
 		rel = table_open(tableoid, NoLock);
 
 		/* initialize estate */
@@ -360,9 +356,6 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type)
 
 		ExecResetTupleTable(estate->es_tupleTable, false);
 		FreeExecutorState(estate);
-
-		PopActiveSnapshot();
-		CommitTransactionCommand();
 	}
 	PG_CATCH();
 	{
@@ -380,7 +373,6 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type)
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	MemoryContextSwitchTo(oldContext);
 	return 0;
 }
 
@@ -406,7 +398,6 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 	EPQState	epqstate;
 	bool found;
 	Oid idxoid = InvalidOid;
-	MemoryContext oldContext = CurrentMemoryContext;
 
 	/*
 	 * we put in TRY and CATCH block to capture potential exceptions raised
@@ -416,9 +407,6 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 	 */
 	PG_TRY();
 	{
-		StartTransactionCommand();
-		PushActiveSnapshot(GetTransactionSnapshot());
-
 		rel = table_open(tableoid, NoLock);
 
 		/* initialize estate */
@@ -552,9 +540,6 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 		ExecResetTupleTable(estate->es_tupleTable, false);
 		FreeExecutorState(estate);
 		table_close(rel, NoLock);
-
-		PopActiveSnapshot();
-		CommitTransactionCommand();
 	}
 	PG_CATCH();
 	{
@@ -572,7 +557,6 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	MemoryContextSwitchTo(oldContext);
 	return ret;
 }
 
@@ -597,7 +581,6 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type)
 	EPQState	epqstate;
 	bool found;
 	Oid idxoid = InvalidOid;
-	MemoryContext oldContext = CurrentMemoryContext;
 
 	/*
 	 * we put in TRY and CATCH block to capture potential exceptions raised
@@ -607,9 +590,6 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type)
 	 */
 	PG_TRY();
 	{
-		StartTransactionCommand();
-		PushActiveSnapshot(GetTransactionSnapshot());
-
 		rel = table_open(tableoid, NoLock);
 
 		/* initialize estate */
@@ -712,9 +692,6 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type)
 		ExecResetTupleTable(estate->es_tupleTable, false);
 		FreeExecutorState(estate);
 		table_close(rel, NoLock);
-
-		PopActiveSnapshot();
-		CommitTransactionCommand();
 	}
 	PG_CATCH();
 	{
@@ -732,7 +709,6 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type)
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	MemoryContextSwitchTo(oldContext);
 	return ret;
 }
 

--- a/synchdb.h
+++ b/synchdb.h
@@ -96,7 +96,6 @@ typedef struct _BatchInfo
 {
 	 int batchId;
 	 int batchSize;
-	 int currRecordIndex;
 } BatchInfo;
 
 /**


### PR DESCRIPTION
performance increased by completing the batch of changes in one single transaction rather than one transaction per change. This makes processing much faster but also renders 'partial batch completion' useless, so it is removed. Synchdb will only marks the entire batch as complete or failed similar to how a transaction works. 