### PR TITLE
consolidate debezium configuration parameters into one single java object

### DIFF
--- a/dbz-engine/src/main/java/com/example/DebeziumRunner.java
+++ b/dbz-engine/src/main/java/com/example/DebeziumRunner.java
@@ -119,7 +119,6 @@ public class DebeziumRunner {
 			logger.warn("hostname = " + this.hostname);
 			logger.warn("port = " + this.port);
 			logger.warn("user = " + this.user);
-			logger.warn("password = " + this.password);
 			logger.warn("database = " + this.database);
 			logger.warn("table = " + this.table);
 			logger.warn("snapshotMode = " + this.snapshotMode);

--- a/dbz-engine/src/main/java/com/example/DebeziumRunner.java
+++ b/dbz-engine/src/main/java/com/example/DebeziumRunner.java
@@ -191,8 +191,8 @@ public class DebeziumRunner {
 	public class ChangeRecordBatch
 	{
 		public int batchid;
-		public final List<ChangeEvent<String, String>> records;
-		public final DebeziumEngine.RecordCommitter committer;
+		public List<ChangeEvent<String, String>> records;
+		public DebeziumEngine.RecordCommitter committer;
 
 		public ChangeRecordBatch(List<ChangeEvent<String, String>> records, DebeziumEngine.RecordCommitter committer) 
 		{
@@ -298,6 +298,7 @@ public class DebeziumRunner {
 		props.setProperty("skipped.operations", myParameters.skippedOperations);
 		props.setProperty("connect.timeout", String.valueOf(myParameters.connectTimeout));
 		props.setProperty("database.query.timeout", String.valueOf(myParameters.queryTimeout));
+		props.setProperty("snapshot.max.threads", "1");
 
 		logger.info("Hello from DebeziumRunner class!");
 
@@ -479,6 +480,12 @@ public class DebeziumRunner {
 			
 			/* remove hash entry at batch completion */
 			activeBatchHash.remove(batchid);
+
+			/* nullify the allocated objects for garbage collection */
+			myBatch.records.clear();
+			myBatch.records = null;
+			myBatch.committer = null;
+			myBatch = null;
 		}
 		else
 		{

--- a/dbz-engine/src/main/java/com/example/DebeziumRunner.java
+++ b/dbz-engine/src/main/java/com/example/DebeziumRunner.java
@@ -52,6 +52,86 @@ public class DebeziumRunner {
 	final int TYPE_SQLSERVER = 3;
 	final int BATCH_QUEUE_SIZE = 3;
 
+	/* MyParameters class - encapsulates all supported debezium parameters */
+	public class MyParameters
+	{
+		/* required parameters - needed to construct this class */
+		private String connectorName;
+		private int connectorType;
+		private String hostname;
+		private int port;
+		private String user;
+		private String password;
+		private String database;
+		private String table;
+		private String snapshotMode;
+
+		/* extended parameters - set incrementally */
+		private int batchSize;
+		private int queueSize;
+		private String skippedOperations;
+		private int connectTimeout;
+		private int queryTimeout;
+
+		/* constructor requires all required parameters for a connector to work */
+		public MyParameters(String connectorName, int connectorType, String hostname, int port, String user, String password, String database, String table, String snapshotMode)
+		{
+			this.connectorName = connectorName;
+			this.connectorType = connectorType;
+			this.hostname = hostname;
+			this.port = port;
+			this.user = user;
+			this.password = password;
+			this.database = database;
+			this.table = table;
+			this.snapshotMode = snapshotMode;
+		}
+		public MyParameters setBatchSize(int batchSize)
+		{
+			this.batchSize = batchSize;
+			return this;
+		}
+		public MyParameters setQueueSize(int queueSize)
+		{
+			this.queueSize = queueSize;
+			return this;
+		}
+		public MyParameters setSkippedOperations(String skippedOperations)
+		{
+			this.skippedOperations = skippedOperations;
+			return this;
+		}
+		public MyParameters setConnectTimeout(int connectTimeout)
+		{
+			this.connectTimeout = connectTimeout;
+			return this;
+		}
+		public MyParameters setQueryTimeout(int queryTimeout)
+		{
+			this.queryTimeout = queryTimeout;
+			return this;
+		}
+		/* add more setters here to incrementally set parameters */
+		public void print()
+		{
+			logger.warn("connectorName = " + this.connectorName);
+			logger.warn("connectorType= " + this.connectorType);
+			logger.warn("hostname = " + this.hostname);
+			logger.warn("port = " + this.port);
+			logger.warn("user = " + this.user);
+			logger.warn("password = " + this.password);
+			logger.warn("database = " + this.database);
+			logger.warn("table = " + this.table);
+			logger.warn("snapshotMode = " + this.snapshotMode);
+
+			logger.warn("batchSize = " + this.batchSize);
+			logger.warn("queueSize = " + this.queueSize);
+			logger.warn("skippedOperations = " + this.skippedOperations);
+			logger.warn("connectTimeout = " + this.connectTimeout);
+			logger.warn("queryTimeout = " + this.queryTimeout);
+		}
+
+	}
 	/* BatchMaanger represents a Batch request queue */
 	public class BatchManager
 	{
@@ -138,72 +218,73 @@ public class DebeziumRunner {
 	    logger.warn("  Max: " + nonHeapUsage.getMax() + " bytes");
 	}
 
-	public void startEngine(String hostname, int port, String user, String password, String database, String table, int connectorType, String name, String snapshot_mode) throws Exception
+	public void startEngine(MyParameters myParameters) throws Exception
 	{
 		String offsetfile = "/dev/shm/offsets.dat";
 		String schemahistoryfile = "/dev/shm/schemahistory.dat";
 
 		Properties props = new Properties();
+		myParameters.print();
 
         /* Setting connector specific properties */
         props.setProperty("name", "engine");
-		switch(connectorType)
+		switch(myParameters.connectorType)
 		{
 			case TYPE_MYSQL:
 			{
 		        props.setProperty("connector.class", "io.debezium.connector.mysql.MySqlConnector");
-				int hash = name.hashCode();
+				int hash = myParameters.connectorName.hashCode();
 				long unsignedhash = Integer.toUnsignedLong(hash);
 				long serverid = 1 + (unsignedhash % (4294967295L - 1));
 
 				logger.warn("derived server id " + serverid);
 				props.setProperty("database.server.id", String.valueOf(serverid));	/* todo: make configurable */
 
-				offsetfile = "pg_synchdb/mysql_" + name + "_offsets.dat";
-				schemahistoryfile = "pg_synchdb/mysql_" + name + "_schemahistory.dat";
+				offsetfile = "pg_synchdb/mysql_" + myParameters.connectorName + "_offsets.dat";
+				schemahistoryfile = "pg_synchdb/mysql_" + myParameters.connectorName + "_schemahistory.dat";
 
 				break;
 			}
 			case TYPE_ORACLE:
 			{
 		        props.setProperty("connector.class", "io.debezium.connector.oracle.OracleConnector");
-				offsetfile = "pg_synchdb/oracle_" + name + "_offsets.dat";
-				schemahistoryfile = "pg_synchdb/oracle_" + name + "_schemahistory.dat";
+				offsetfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_offsets.dat";
+				schemahistoryfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_schemahistory.dat";
 				break;
 			}
 			case TYPE_SQLSERVER:
 			{
 		        props.setProperty("connector.class", "io.debezium.connector.sqlserver.SqlServerConnector");
 				props.setProperty("database.encrypt", "false");	/* todo: enable tls */
-				offsetfile = "pg_synchdb/sqlserver_" + name + "_offsets.dat";
-				schemahistoryfile = "pg_synchdb/sqlserver_" + name + "_schemahistory.dat";
+				offsetfile = "pg_synchdb/sqlserver_" + myParameters.connectorName + "_offsets.dat";
+				schemahistoryfile = "pg_synchdb/sqlserver_" + myParameters.connectorName + "_schemahistory.dat";
 				break;
 			}
 		}
 		
 		/* setting common properties */
-		if (database.equals("null"))
+		if (myParameters.database.equals("null"))
 			logger.warn("database is null - skip setting database.include.list property");
 		else
 		{
-			props.setProperty("database.include.list", database);
-			props.setProperty("database.names", database);
+			props.setProperty("database.include.list", myParameters.database);
+			props.setProperty("database.names", myParameters.database);
 		}
 
-		if (table.equals("null"))
+		if (myParameters.table.equals("null"))
 			logger.warn("table is null - skip setting table.include.list property");
 		else
-			props.setProperty("table.include.list", table);
+			props.setProperty("table.include.list", myParameters.table);
 		
-		if (snapshot_mode.equals("null"))
+		if (myParameters.snapshotMode.equals("null"))
 			logger.warn("snapshot_mode is null - skip setting snapshot.mode property");
 		else
-			props.setProperty("snapshot.mode", snapshot_mode);
+			props.setProperty("snapshot.mode", myParameters.snapshotMode);
 
-		props.setProperty("database.hostname", hostname);
-		props.setProperty("database.port", String.valueOf(port));
-		props.setProperty("database.user", user);
-		props.setProperty("database.password", password);
+		props.setProperty("database.hostname", myParameters.hostname);
+		props.setProperty("database.port", String.valueOf(myParameters.port));
+		props.setProperty("database.user", myParameters.user);
+		props.setProperty("database.password", myParameters.password);
 		props.setProperty("topic.prefix", "synchdb-connector");
 		props.setProperty("schema.history.internal", "io.debezium.storage.file.history.FileSchemaHistory");
 		props.setProperty("schema.history.internal.file.filename", schemahistoryfile);
@@ -211,9 +292,12 @@ public class DebeziumRunner {
 		props.setProperty("offset.storage.file.filename", offsetfile);
 		props.setProperty("offset.flush.interval.ms", "60000");
 		props.setProperty("schema.history.internal.store.only.captured.tables.ddl", "true");
-		props.setProperty("max.batch.size", "4096");
-		props.setProperty("max.queue.size", "8192");
+		props.setProperty("max.batch.size", String.valueOf(myParameters.batchSize));
+		props.setProperty("max.queue.size", String.valueOf(myParameters.queueSize));
 		props.setProperty("record.processing.order", "ORDERED");
+		props.setProperty("skipped.operations", myParameters.skippedOperations);
+		props.setProperty("connect.timeout", String.valueOf(myParameters.connectTimeout));
+		props.setProperty("database.query.timeout", String.valueOf(myParameters.queryTimeout));
 
 		logger.info("Hello from DebeziumRunner class!");
 

--- a/synchdb.h
+++ b/synchdb.h
@@ -30,7 +30,6 @@
 #define SYNCHDB_CONNINFO_DB_NAME_SIZE 64
 #define SYNCHDB_MAX_ACTIVE_CONNECTORS 30
 
-/* 90s is Debezium's default timeout value, 10 is SynchDB value */
 #define DEBEZIUM_SHUTDOWN_TIMEOUT_MSEC 100000
 
 #define SYNCHDB_OFFSET_SIZE 256


### PR DESCRIPTION
debezium has a lot of parameters that we can tune, and so far we have exposed a few of them and we may expose more in the future. To make it easier to pass increasing number of parameters to debezium on the java side, I have consolidated some of the frequently used parameters into a MyParameters inner class inside DebeziumRunner. So Synchdb extension on PostgreSQL side can incrementally construct this MyParameters object and pass it down to Debezium as a single argument rather than multiple.

When we decide to expose more debezium parameters as configurable we simply write some code to incrementally add new parameters to MyParameters object class on both java and synchdb sides.

Also tested a 100k table initial snapshot with mode "no_data", and it requires at least 2G memory allocated to JVM to hold all the schema info. This max heap memory for JVM is also configurable now