### PR TITLE
remove signal table for incremental snapshot setting for now

### DIFF
--- a/dbz-engine/src/main/java/com/example/DebeziumRunner.java
+++ b/dbz-engine/src/main/java/com/example/DebeziumRunner.java
@@ -460,7 +460,7 @@ public class DebeziumRunner {
 		props.setProperty("snapshot.max.threads", String.valueOf(myParameters.snapshotThreadNum));
 		props.setProperty("signal.enabled.channels", "file");
 		props.setProperty("signal.file", signalfile);
-		props.setProperty("signal.data.collection", "synchdb.dbzsignal");	/* todo: make it configurable */
+		//props.setProperty("signal.data.collection", "synchdb.dbzsignal");	/* todo: make it configurable */
 		props.setProperty("incremental.snapshot.chunk.size", String.valueOf(myParameters.incrementalSnapshotChunkSize));
 		props.setProperty("incremental.snapshot.watermarking.strategy", myParameters.incrementalSnapshotWatermarkingStrategy);
 		props.setProperty("incremental.snapshot.allow.schema.changes", "false");


### PR DESCRIPTION
leaving this config there in debezium may cause trouble later because this is a special signaling table for triggering incremental snapshot and actually not being captured. Incremental snapshot is to be supported later but for now, so we will add it back one everything is thoroughly tested