### PR TITLE
fixed an issue where char is mapped to incorrect size in sqlserver connector

### DIFF
--- a/format_converter.c
+++ b/format_converter.c
@@ -143,7 +143,7 @@ DatatypeHashEntry sqlserver_defaultTypeMappings[] =
 	{{"datetime2", false}, "TIMESTAMP", 0},
 	{{"datetimeoffset", false}, "TIMESTAMPTZ", 0},
 	{{"smalldatetime", false}, "TIMESTAMP", 0},
-	{{"char", false}, "CHAR", 0},
+	{{"char", false}, "CHAR", -1},
 	{{"varchar", false}, "VARCHAR", -1},
 	{{"text", false}, "TEXT", 0},
 	{{"nchar", false}, "CHAR", 0},


### PR DESCRIPTION
the default data type mapping would try to map char -> char with size 0, which defaults to 1 in PostgreSQL. This is incorrect. We should set the default mapping size to -1. which means to use whatever size debezium change event tells us. 