### PR TITLE
added synchdb_stats_view() to collect and show connector statistics info

### DIFF
--- a/dbz-engine/src/main/java/com/example/DebeziumRunner.java
+++ b/dbz-engine/src/main/java/com/example/DebeziumRunner.java
@@ -639,7 +639,7 @@ public class DebeziumRunner {
 		
 		if (markall)
 		{
-			logger.warn("debezium marked all records in batchid(" + batchid + ") as processed");
+			logger.info("debezium marked all records in batchid(" + batchid + ") as processed");
 
 			for (i = 0; i < myBatch.records.size(); i++)
 			{

--- a/format_converter.h
+++ b/format_converter.h
@@ -152,7 +152,7 @@ typedef struct transformExpressionHashEntry
 } TransformExpressionHashEntry;
 
 /* Function prototypes */
-int fc_processDBZChangeEvent(const char * event);
+int fc_processDBZChangeEvent(const char * event, SynchdbStatistics * myBatchStats);
 ConnectorType fc_get_connector_type(const char * connector);
 void fc_initFormatConverter(ConnectorType connectorType);
 void fc_deinitFormatConverter(ConnectorType connectorType);

--- a/replication_agent.h
+++ b/replication_agent.h
@@ -49,7 +49,7 @@ typedef struct pg_dml
 
 /* Function prototypes */
 int ra_executePGDDL(PG_DDL * pgddl, ConnectorType type);
-int ra_executePGDML(PG_DML * pgdml, ConnectorType type);
+int ra_executePGDML(PG_DML * pgdml, ConnectorType type, SynchdbStatistics * myBatchStats);
 int ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** connector);
 int ra_executeCommand(const char * query);
 int ra_listConnInfoNames(char ** out, int * numout);

--- a/synchdb--1.0.sql
+++ b/synchdb--1.0.sql
@@ -17,7 +17,7 @@ CREATE OR REPLACE FUNCTION synchdb_get_state() RETURNS SETOF record
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
-CREATE VIEW synchdb_state_view AS SELECT * FROM synchdb_get_state() AS (id int, connector text, conninfo_name text, pid int, stage text, state text, err text, last_dbz_offset text);
+CREATE VIEW synchdb_state_view AS SELECT * FROM synchdb_get_state() AS (id int, connector text, name text, pid int, stage text, state text, err text, last_dbz_offset text);
 
 CREATE OR REPLACE FUNCTION synchdb_pause_engine(text) RETURNS int
 AS '$libdir/synchdb'
@@ -43,6 +43,12 @@ CREATE OR REPLACE FUNCTION synchdb_log_jvm_meminfo(text) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
---CREATE TABLE IF NOT EXISTS synchdb_conninfo(name TEXT PRIMARY KEY, host TEXT NOT NULL, port INTEGER NOT NULL CHECK (port > 0 AND port <= 65535), username TEXT NOT NULL, password BYTEA);
+CREATE OR REPLACE FUNCTION synchdb_get_stats() RETURNS SETOF record
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE VIEW synchdb_stats_view AS SELECT * FROM synchdb_get_stats() AS (name text, ddls bigint, dmls bigint, reads bigint, creates bigint, updates bigint, deletes bigint, bad_events bigint, total_events bigint, batches_done bigint, avg_batch_size bigint);
+
 CREATE TABLE IF NOT EXISTS synchdb_conninfo(name TEXT PRIMARY KEY, isactive BOOL, data JSONB);
+
 

--- a/synchdb.h
+++ b/synchdb.h
@@ -93,6 +93,24 @@ typedef enum _connectorStage
 } ConnectorStage;
 
 /**
+ * ConnectorStatistics - Enum representing different statistics of a connector
+ */
+typedef enum _connectorStatistics
+{
+	STATS_UNDEF = 0,
+	STATS_DDL,
+	STATS_DML,
+	STATS_READ,
+	STATS_CREATE,
+	STATS_UPDATE,
+	STATS_DELETE,
+	STATS_BAD_CHANGE_EVENT,
+	STATS_TOTAL_CHANGE_EVENT,
+	STATS_BATCH_COMPLETION,
+	STATS_AVERAGE_BATCH_SIZE
+} ConnectorStatistics;
+
+/**
  * BatchInfo - Structure containing the metadata of a batch change request
  */
 typedef struct _BatchInfo
@@ -144,6 +162,29 @@ typedef struct _SynchdbRequest
 } SynchdbRequest;
 
 /**
+ * SynchdbRequest - Structure representing a statistic info per connector.
+ * If you add new stats values here, make sure to add the same to ConnectorStatistics
+ * enum above
+ *
+ * todo: to be persisted in future
+ */
+typedef struct _SynchdbStatistics
+{
+	unsigned long long stats_ddl;				/* number of DDL operations performed */
+	unsigned long long stats_dml;				/* number of DML operations performed */
+	unsigned long long stats_read;				/* READ events generated during initial snapshot */
+	unsigned long long stats_create;			/* INSERT events generated during CDC */
+	unsigned long long stats_update;			/* UPDATE events generated during CDC */
+	unsigned long long stats_delete;			/* DELETE events generated during CDC */
+	unsigned long long stats_bad_change_event;	/* number of bad change events */
+	unsigned long long stats_total_change_event;/* number of total change events */
+	unsigned long long stats_batch_completion;	/* number of batches completed */
+	unsigned long long stats_average_batch_size;/* calculated average batch size: */
+
+	/* todo: more stats to be added */
+} SynchdbStatistics;
+
+/**
  *  Structure holding state information for connectors
  */
 typedef struct _ActiveConnectors
@@ -157,6 +198,7 @@ typedef struct _ActiveConnectors
 	char dbzoffset[SYNCHDB_OFFSET_SIZE];
 	char snapshotMode[SYNCHDB_SNAPSHOT_MODE_SIZE];
 	ConnectionInfo conninfo;
+	SynchdbStatistics stats;
 } ActiveConnectors;
 
 /**
@@ -182,5 +224,6 @@ ConnectorState get_shm_connector_state_enum(int connectorId);
 const char* connectorTypeToString(ConnectorType type);
 void set_shm_connector_stage(int connectorId, ConnectorStage stage);
 ConnectorStage get_shm_connector_stage_enum(int connectorId);
+void increment_connector_statistics(SynchdbStatistics * myStats, ConnectorStatistics which, int incby);
 
 #endif /* SYNCHDB_SYNCHDB_H_ */


### PR DESCRIPTION
added synchdb_stats_view() to collect and show connector statistic info

These statistics record cumulative measurements about different types of change events a connector has processed so far. Currently these statistic values are stored in shared memory and not persisted to disk. Persist statistics data is a feature to be added in near future.

See below for an example output:
```sql
postgres=# select * from synchdb_stats_view;
   connector   | ddls |  dmls   |  reads  | creates | updates | deletes | bad_events | total_events | batches_done | avg_batch_size
---------------+------+---------+---------+---------+---------+---------+------------+--------------+--------------+----------------
 mysqltpccconn |   22 | 3887111 | 3263746 |  208684 |  400241 |   14440 |      14444 |      3901573 |         2441 |           1598
               |    0 |       0 |       0 |       0 |       0 |       0 |          0 |            0 |            0 |              0
               |    0 |       0 |       0 |       0 |       0 |       0 |          0 |            0 |            0 |              0
               |    0 |       0 |       0 |       0 |       0 |       0 |          0 |            0 |            0 |              0
               |    0 |       0 |       0 |       0 |       0 |       0 |          0 |            0 |            0 |              0
  ...
  ...
```

Column Details:

| fields | description |
|-|-|
| name | the associated connector info name created by `synchdb_add_conninfo()`|
| ddls | number of DDLs operations completed |
| dmls | number of DMLs operations completed |
| reads | number of READ events completed during initial snapshot stage |
| creates | number of CREATES events completed during CDC stage |
| updates | number of UPDATES events completed during CDC stage |
| deletes | number of DELETES events completed during CDC stage |
| bad_events | number of bad events ignored (such as empty events, unsupported DDL events..etc) |
| total_events | total number of events processed (including bad_events) |
| batches_done | number of batches completed |
| avg_batch_size | average batch size (total_events / batches_done) |
