### PR TITLE
added synchdb_reset_stats, make max connectors configurable, and fix auto startup issues

### DIFF
--- a/synchdb--1.0.sql
+++ b/synchdb--1.0.sql
@@ -17,7 +17,7 @@ CREATE OR REPLACE FUNCTION synchdb_get_state() RETURNS SETOF record
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
-CREATE VIEW synchdb_state_view AS SELECT * FROM synchdb_get_state() AS (id int, connector text, name text, pid int, stage text, state text, err text, last_dbz_offset text);
+CREATE VIEW synchdb_state_view AS SELECT * FROM synchdb_get_state() AS (name text, connector_type text, pid int, stage text, state text, err text, last_dbz_offset text);
 
 CREATE OR REPLACE FUNCTION synchdb_pause_engine(text) RETURNS int
 AS '$libdir/synchdb'
@@ -44,6 +44,10 @@ AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
 CREATE OR REPLACE FUNCTION synchdb_get_stats() RETURNS SETOF record
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION synchdb_reset_stats(text) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 

--- a/synchdb.h
+++ b/synchdb.h
@@ -28,7 +28,7 @@
 #define SYNCHDB_CONNINFO_TABLELIST_SIZE 256
 #define SYNCHDB_CONNINFO_RULEFILENAME_SIZE 64
 #define SYNCHDB_CONNINFO_DB_NAME_SIZE 64
-#define SYNCHDB_MAX_ACTIVE_CONNECTORS 30
+//#define SYNCHDB_MAX_ACTIVE_CONNECTORS 30
 
 #define DEBEZIUM_SHUTDOWN_TIMEOUT_MSEC 100000
 
@@ -138,6 +138,15 @@ typedef struct _ConnectionInfo
 } ConnectionInfo;
 
 /**
+ * ConnectorName - Used to store as a List* of names for automatic connector
+ * resume feature
+ */
+typedef struct _ConnectorName
+{
+	char name[SYNCHDB_CONNINFO_NAME_SIZE];
+} ConnectorName;
+
+/**
  * ExtraConnectionInfo - Extra DBZ Connection info parameters read from the
  * rule file (if specified). These won't be put in shared memory so they
  * are declared as pointers.
@@ -207,7 +216,7 @@ typedef struct _ActiveConnectors
 typedef struct _SynchdbSharedState
 {
 	LWLock		lock;		/* mutual exclusion */
-	ActiveConnectors connectors[SYNCHDB_MAX_ACTIVE_CONNECTORS];
+	ActiveConnectors * connectors;
 } SynchdbSharedState;
 
 /* Function prototypes */


### PR DESCRIPTION
* a connector's stats can be reset with synchdb_reset_stats('name'). User has to specify a connector name to reset, it does not reset all stats
* synchdb_states_view and synchdb_stats_view will now only display active entries only
* fixed a crash when automatically launching more than one connector at postgresql startup
* max number of connector workers that synchdb can spawn is now configurable as `synchdb.max_connector_workers`
* adjust the output of synchdb_state_view to match synchdb_stats_view such that `name` is the first column