### PR TITLE
added new GUCs to control error handling strategies and log levels

### DIFF
--- a/dbz-engine/src/main/resources/log4j.properties
+++ b/dbz-engine/src/main/resources/log4j.properties
@@ -1,9 +1,0 @@
-# Root logger option
-log4j.rootLogger=WARN, stdout
-
-# Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
-

--- a/synchdb.h
+++ b/synchdb.h
@@ -28,7 +28,6 @@
 #define SYNCHDB_CONNINFO_TABLELIST_SIZE 256
 #define SYNCHDB_CONNINFO_RULEFILENAME_SIZE 64
 #define SYNCHDB_CONNINFO_DB_NAME_SIZE 64
-//#define SYNCHDB_MAX_ACTIVE_CONNECTORS 30
 
 #define DEBEZIUM_SHUTDOWN_TIMEOUT_MSEC 100000
 
@@ -49,8 +48,8 @@
  */
 #define SYNCHDB_OFFSET_FILE_PATTERN "pg_synchdb/%s_%s_offsets.dat"
 #define SYNCHDB_SECRET "930e62fb8c40086c23f543357a023c0c"
-
 #define SYNCHDB_CONNINFO_TABLE "synchdb_conninfo"
+
 /* Enumerations */
 
 /**
@@ -109,6 +108,33 @@ typedef enum _connectorStatistics
 	STATS_BATCH_COMPLETION,
 	STATS_AVERAGE_BATCH_SIZE
 } ConnectorStatistics;
+
+/**
+ * ErrorStrategies - Enum representing different strategies to handle and error
+ */
+typedef enum _ErrorStrategies
+{
+	STRAT_UNDEF = 0,
+	STRAT_EXIT_ON_ERROR,
+	STRAT_SKIP_ON_ERROR,
+	STRAT_RETRY_ON_ERROR
+} ErrorStrategies;
+
+/**
+ * ErrorStrategies - Log levels of Debezium runner
+ */
+typedef enum _DbzLogLevels
+{
+	LOG_LEVEL_UNDEF = 0,
+	LOG_LEVEL_ALL,
+	LOG_LEVEL_DEBUG,
+	LOG_LEVEL_INFO,
+	LOG_LEVEL_WARN,
+	LOG_LEVEL_ERROR,
+	LOG_LEVEL_FATAL,
+	LOG_LEVEL_OFF,
+	LOG_LEVEL_TRACE
+} DbzLogLevels;
 
 /**
  * BatchInfo - Structure containing the metadata of a batch change request


### PR DESCRIPTION
1) added a new GUC synchdb.error_handling_strategy to control the strategy to handle an error: can be skip, exit or retry.

default is `exit`, which means the connector will exit when it encounters an error during apply. Can also be `skip`, which will make the connector skip the error (this causes the "bad event" statistics to increment) without exiting. Or set to `retry` to cause the connector to exit, and then restarted by postgresql to process the last change event again.

2) added a new GUC synchdb.dbz_log_level to control the log level of log4j used by Debezium runner engine

new GUCs to control the log level of debezium runner engine so we have an option to see debezium's working logs if desired