### PR TITLE
enabled oracle connector in SynchDB

### DIFF
--- a/dbz-engine/pom.xml
+++ b/dbz-engine/pom.xml
@@ -51,6 +51,11 @@
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
+      <artifactId>debezium-connector-oracle</artifactId>
+      <version>2.6.2.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.debezium</groupId>
       <artifactId>debezium-connector-sqlserver</artifactId>
       <version>2.6.2.Final</version>
     </dependency>

--- a/dbz-engine/src/main/java/com/example/DebeziumRunner.java
+++ b/dbz-engine/src/main/java/com/example/DebeziumRunner.java
@@ -400,6 +400,14 @@ public class DebeziumRunner {
 				schemahistoryfile = "pg_synchdb/mysql_" + myParameters.connectorName + "_schemahistory.dat";
 				signalfile = "pg_synchdb/mysql_" + myParameters.connectorName + "_signal.dat";
 
+				if (myParameters.database.equals("null"))
+					logger.warn("database is null - skip setting database.include.list property");
+				else
+				{
+					props.setProperty("database.include.list", myParameters.database);
+					props.setProperty("database.names", myParameters.database);
+				}
+
 				if (myParameters.sslmode != null)
 					props.setProperty("database.ssl.mode", myParameters.sslmode);
 				if (myParameters.sslKeystore != null)
@@ -419,6 +427,19 @@ public class DebeziumRunner {
 				offsetfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_offsets.dat";
 				schemahistoryfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_schemahistory.dat";
 				signalfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_signal.dat";
+
+                props.setProperty("database.dbname", myParameters.database);
+				if (myParameters.database.equals("null"))
+                    logger.warn("database is null - skip setting database.include.list property");
+                else
+                {
+                    props.setProperty("database.dbname", myParameters.database);
+                }
+				/* limit to this Oracle user's schema for now so we do not replicate tables from other schemas */
+				props.setProperty("schema.include.list", myParameters.user);
+				props.setProperty("lob.enabled", "true");
+				props.setProperty("poll.interval.ms", "100");
+				props.setProperty("unavailable.value.placeholder", "__synchdb_unavailable_value");
 				break;
 			}
 			case TYPE_SQLSERVER:
@@ -428,6 +449,14 @@ public class DebeziumRunner {
 				schemahistoryfile = "pg_synchdb/sqlserver_" + myParameters.connectorName + "_schemahistory.dat";
 				signalfile = "pg_synchdb/sqlserver_" + myParameters.connectorName + "_signal.dat";
 				
+				if (myParameters.database.equals("null"))
+					logger.warn("database is null - skip setting database.include.list property");
+				else
+				{
+					props.setProperty("database.include.list", myParameters.database);
+					props.setProperty("database.names", myParameters.database);
+				}
+
 				if (myParameters.sslmode != null && !myParameters.sslmode.equals("disabled"))
 					props.setProperty("database.encrypt", "true");
 				else
@@ -446,13 +475,6 @@ public class DebeziumRunner {
 		}
 		
 		/* setting common properties */
-		if (myParameters.database.equals("null"))
-			logger.warn("database is null - skip setting database.include.list property");
-		else
-		{
-			props.setProperty("database.include.list", myParameters.database);
-			props.setProperty("database.names", myParameters.database);
-		}
 
 		if (myParameters.table.equals("null"))
 			logger.warn("table is null - skip setting table.include.list property");
@@ -776,7 +798,7 @@ public class DebeziumRunner {
 			case TYPE_ORACLE:
 			{
 				inputFile = new File("pg_synchdb/oracle_" + name + "_offsets.dat");
-				/* todo */
+				key = "[\"engine\",{\"server\":\"synchdb-connector\"}]";
 				break;
 			}
 			case TYPE_SQLSERVER:
@@ -829,8 +851,7 @@ public class DebeziumRunner {
 			}
 			case TYPE_ORACLE:
 			{
-				key = "[\"engine\",{\"server\":\"synchdb-connector\",\"database\":\"" + db + "\"}]";
-				/* todo */
+				key = "[\"engine\",{\"server\":\"synchdb-connector\"}]";
 				break;
 			}
 			case TYPE_SQLSERVER:

--- a/format_converter.h
+++ b/format_converter.h
@@ -41,6 +41,8 @@ typedef enum _timeRep
 	TIME_MICROTIMESTAMP,	/* number of microseconds since epoch */
 	TIME_NANOTIMESTAMP,		/* number of nanoseconds since epoch */
 	TIME_ZONEDTIMESTAMP,	/* string representation of timestamp with timezone */
+	TIME_MICRODURATION,	/* duration expressed in microseconds */
+	DATA_VARIABLE_SCALE,	/* indication if scale is variable (for oracle) */
 } TimeRep;
 
 /* Structure to represent a column in a DDL event */

--- a/replication_agent.c
+++ b/replication_agent.c
@@ -519,13 +519,6 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 
 		/* We must open indexes here. */
 		ExecOpenIndices(resultRelInfo, false);
-
-		/*
-		 * check if there is a PK or relation identity index that we could use to
-		 * locate the old tuple. If no identity or PK, there may potentially be
-		 * other indexes created on other columns that can be used. But for now,
-		 * we do not bother checking for them. Mark it as todo for later.
-		 */
 		idxoid = GetRelationIdentityOrPK(rel);
 		if (OidIsValid(idxoid))
 		{
@@ -721,13 +714,6 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type)
 
 		/* We must open indexes here. */
 		ExecOpenIndices(resultRelInfo, false);
-
-		/*
-		 * check if there is a PK or relation identity index that we could use to
-		 * locate the old tuple. If no identity or PK, there may potentially be
-		 * other indexes created on other columns that can be used. But for now,
-		 * we do not bother checking for them. Mark it as todo for later.
-		 */
 		idxoid = GetRelationIdentityOrPK(rel);
 		if (OidIsValid(idxoid))
 		{

--- a/replication_agent.c
+++ b/replication_agent.c
@@ -37,6 +37,8 @@ extern bool synchdb_dml_use_spi;
 extern uint64 SPI_processed;
 extern int myConnectorId;
 extern int synchdb_error_strategy;
+extern bool synchdb_log_event_on_error;
+extern char * g_eventStr;
 
 /*
  * swap_tokens
@@ -277,6 +279,10 @@ spi_execute(const char * query, ConnectorType type)
 		if (errdata)
 			set_shm_connector_errmsg(myConnectorId, errdata->message);
 
+		/* dump the JSON change event as additional detail if available */
+		if (synchdb_log_event_on_error && g_eventStr != NULL)
+			elog(LOG, "%s", g_eventStr);
+
 		FreeErrorData(errdata);
 		SPI_finish();
 		ret = -1;
@@ -405,6 +411,10 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type)
 			pfree(msg);
 		}
 		FreeErrorData(errdata);
+
+		/* dump the JSON change event as additional detail if available */
+		if (synchdb_log_event_on_error && g_eventStr != NULL)
+			elog(LOG, "%s", g_eventStr);
 
 		if (synchdb_error_strategy == STRAT_SKIP_ON_ERROR)
 		{
@@ -574,7 +584,7 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 		}
 		else
 		{
-			elog(DEBUG1, "tuple to update not found");
+			elog(ERROR, "tuple to update not found");
 			ret = -1;
 		}
 
@@ -603,6 +613,10 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 			pfree(msg);
 		}
 		FreeErrorData(errdata);
+
+		/* dump the JSON change event as additional detail if available */
+		if (synchdb_log_event_on_error && g_eventStr != NULL)
+			elog(LOG, "%s", g_eventStr);
 
 		if (synchdb_error_strategy == STRAT_SKIP_ON_ERROR)
 		{
@@ -741,7 +755,7 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type)
 		}
 		else
 		{
-			elog(DEBUG1, "tuple to delete not found");
+			elog(ERROR, "tuple to delete not found");
 			ret = -1;
 		}
 
@@ -770,6 +784,10 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type)
 			pfree(msg);
 		}
 		FreeErrorData(errdata);
+
+		/* dump the JSON change event as additional detail if available */
+		if (synchdb_log_event_on_error && g_eventStr != NULL)
+			elog(LOG, "%s", g_eventStr);
 
 		if (synchdb_error_strategy == STRAT_SKIP_ON_ERROR)
 		{


### PR DESCRIPTION
* oracle connector type can now be selected when creating a connector info
* support interval data type and its variants 
* support oracle's variable scale numbers 
* support CREATE, INSERT, UPDATE and DELETE operations for oracle
* if connector encounters an error, it will print the JSON change event in log to help with debugging. This can be controlled by the new GUC `synchdb.log_change_on_error`

known issue:
if source table has BLOB, CLOB or NCLOB data type and synchdb has configuration synchdb_dml_use_spi = true, then UPDATE and DELETE will not actually be done because Oracle does not supply the old value of BLOB, CLOB, or NCLOB during update or delete so synchdb would not be able to identify the old tuple to update. This would not be an issue if synchdb_dml_use_spi = false, which is the default setting

