### PR TITLE
initial commit for synchdb v1.1 with new table attribute comparison view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 MODULE_big = synchdb
 
 EXTENSION = synchdb
-DATA = synchdb--1.0.sql
+DATA = synchdb--1.0.sql synchdb--1.0--1.1.sql
 PGFILEDESC = "synchdb - allows logical replication with heterogeneous databases"
 
 REGRESS = synchdb

--- a/replication_agent.h
+++ b/replication_agent.h
@@ -25,9 +25,25 @@
 typedef struct pg_ddl
 {
 	char * ddlquery;	/* to be fed into SPI*/
+	char * type;		/* CREATE, DROP or ALTER-ADD, ALTER-DROP or ALTER */
+	char * schema;		/* name of PG schema */
+	char * tbname;		/* name of PG table */
+	List * columns;		/* list of PG_DDL_COLUMN */
 } PG_DDL;
 
-typedef struct pg_ddl_column_value
+/*
+ * Structure to represent a PG column in a DDL event that is
+ * sufficient to update the attribute table. It does not need
+ * to contain full column information
+ */
+typedef struct pg_ddl_column
+{
+	char * attname;
+	char * atttype;
+	int position;
+} PG_DDL_COLUMN;
+
+typedef struct pg_dml_column_value
 {
 	char * value;	/* string representation of column values that
 					 * is processed and ready to be used to built

--- a/synchdb--1.0--1.1.sql
+++ b/synchdb--1.0--1.1.sql
@@ -19,7 +19,7 @@ CREATE VIEW synchdb_att_view AS
 		synchdb_attribute.ext_attname,
 		pg_attribute.attname AS pg_attname,
 		synchdb_attribute.ext_atttypename,
-		(SELECT typname FROM pg_type WHERE pg_type.oid = pg_attribute.atttypid) AS pg_atttypid
+		(SELECT typname FROM pg_type WHERE pg_type.oid = pg_attribute.atttypid) AS pg_atttypename
 	FROM synchdb_attribute
 	LEFT JOIN pg_attribute
 	ON synchdb_attribute.attrelid = pg_attribute.attrelid

--- a/synchdb--1.0--1.1.sql
+++ b/synchdb--1.0--1.1.sql
@@ -1,0 +1,28 @@
+\echo Use "CREATE EXTENSION synchdb" to load this file. \quit
+
+CREATE TABLE IF NOT EXISTS synchdb_attribute (
+    connector name,
+    attrelid oid,
+    attnum smallint,
+    ext_tbname name,
+    ext_attname name,
+    ext_atttypename name,
+    PRIMARY KEY (connector, attrelid, attnum)
+);
+
+CREATE VIEW synchdb_att_view AS
+	SELECT
+		connector,
+		synchdb_attribute.attnum,
+		ext_tbname,
+		(SELECT n.nspname || '.' || c.relname AS table_full_name FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.oid=pg_attribute.attrelid) AS pg_tbname,
+		synchdb_attribute.ext_attname,
+		pg_attribute.attname AS pg_attname,
+		synchdb_attribute.ext_atttypename,
+		(SELECT typname FROM pg_type WHERE pg_type.oid = pg_attribute.atttypid) AS pg_atttypid
+	FROM synchdb_attribute
+	LEFT JOIN pg_attribute
+	ON synchdb_attribute.attrelid = pg_attribute.attrelid
+	AND synchdb_attribute.attnum = pg_attribute.attnum
+	ORDER BY (connector, ext_tbname, synchdb_attribute.attnum);
+

--- a/synchdb--1.0.sql
+++ b/synchdb--1.0.sql
@@ -54,5 +54,3 @@ LANGUAGE C IMMUTABLE STRICT;
 CREATE VIEW synchdb_stats_view AS SELECT * FROM synchdb_get_stats() AS (name text, ddls bigint, dmls bigint, reads bigint, creates bigint, updates bigint, deletes bigint, bad_events bigint, total_events bigint, batches_done bigint, avg_batch_size bigint);
 
 CREATE TABLE IF NOT EXISTS synchdb_conninfo(name TEXT PRIMARY KEY, isactive BOOL, data JSONB);
-
-

--- a/synchdb.control
+++ b/synchdb.control
@@ -1,6 +1,6 @@
 # synchdb postgresql extension
 comment = 'synchdb extension'
-default_version = '1.0'
+default_version = '1.1'
 module_pathname = '$libdir/synchdb'
 relocatable = true
 requires = 'pgcrypto'

--- a/synchdb.h
+++ b/synchdb.h
@@ -49,6 +49,7 @@
 #define SYNCHDB_OFFSET_FILE_PATTERN "pg_synchdb/%s_%s_offsets.dat"
 #define SYNCHDB_SECRET "930e62fb8c40086c23f543357a023c0c"
 #define SYNCHDB_CONNINFO_TABLE "synchdb_conninfo"
+#define SYNCHDB_ATTRIBUTE_TABLE "synchdb_attribute"
 
 /* Enumerations */
 


### PR DESCRIPTION
1. synchdb creates a new table 'synchdb_attribute' that stores all the demote table attributes infor that synchdb is currently capturing. 
2. added a new view 'synchdb_att_view' that will join the contents from pg_attribute and synchdb_attribute to show a side-by-side comparison of data type, table and column name mappings
3. when alter table change event wants to add a primary key, synchdb will only do so when the table has no primary key
4. remove the ability to configure a connector to connect to a different database other than the one where synchdb is installed.
5. at the end of every DDL change event processing, synchdb will attempt to update the synchdb_attribute table