### PR TITLE
Synchdb devel

### DIFF
--- a/dbz-engine/src/main/java/com/example/DebeziumRunner.java
+++ b/dbz-engine/src/main/java/com/example/DebeziumRunner.java
@@ -626,6 +626,7 @@ public class DebeziumRunner {
 		if (batchManager != null)
 		{
 			batchManager.shutdown();
+			batchManager = null;
 		}
 		if (engine != null)
 		{

--- a/format_converter.c
+++ b/format_converter.c
@@ -5204,7 +5204,6 @@ fc_load_rules(ConnectorType connectorType, const char * rulefile)
 	char * key = NULL;
 	char * value = NULL;
 	bool found = 0;
-	StringInfoData strinfo;
 
 	HTAB * rulehash = NULL;
 	DatatypeHashEntry hashentry;
@@ -5607,33 +5606,6 @@ fc_load_rules(ConnectorType connectorType, const char * rulefile)
 			value = NULL;
 		}
 	}
-
-	/* load extra per-connector parameters here if specified */
-	initStringInfo(&strinfo);
-
-	getPathElementString(jb, "ssl_rules.ssl_mode", &strinfo, true);
-	if (strcasecmp(strinfo.data, "NULL"))
-		extraConnInfo.ssl_mode = pstrdup(strinfo.data);
-
-	getPathElementString(jb, "ssl_rules.ssl_keystore", &strinfo, true);
-	if (strcasecmp(strinfo.data, "NULL"))
-		extraConnInfo.ssl_keystore = pstrdup(strinfo.data);
-
-	getPathElementString(jb, "ssl_rules.ssl_keystore_pass", &strinfo, true);
-	if (strcasecmp(strinfo.data, "NULL"))
-		extraConnInfo.ssl_keystore_pass = pstrdup(strinfo.data);
-
-	getPathElementString(jb, "ssl_rules.ssl_truststore", &strinfo, true);
-	if (strcasecmp(strinfo.data, "NULL"))
-		extraConnInfo.ssl_truststore = pstrdup(strinfo.data);
-
-	getPathElementString(jb, "ssl_rules.ssl_truststore_pass", &strinfo, true);
-	if (strcasecmp(strinfo.data, "NULL"))
-		extraConnInfo.ssl_truststore_pass = pstrdup(strinfo.data);
-
-	if (strinfo.data)
-		pfree(strinfo.data);
-
 	return true;
 }
 

--- a/format_converter.c
+++ b/format_converter.c
@@ -61,179 +61,179 @@ static HTAB * sqlserverDatatypeHash;
 
 DatatypeHashEntry mysql_defaultTypeMappings[] =
 {
-	{{"INT", true}, "SERIAL", 0},
-	{{"BIGINT", true}, "BIGSERIAL", 0},
-	{{"SMALLINT", true}, "SMALLSERIAL", 0},
-	{{"MEDIUMINT", true}, "SERIAL", 0},
-	{{"ENUM", false}, "TEXT", 0},
-	{{"SET", false}, "TEXT", 0},
-	{{"BIGINT", false}, "BIGINT", 0},
-	{{"BIGINT UNSIGNED", false}, "NUMERIC", -1},
-	{{"NUMERIC UNSIGNED", false}, "NUMERIC", -1},
-	{{"DEC", false}, "DECIMAL", -1},
-	{{"DEC UNSIGNED", false}, "DECIMAL", -1},
-	{{"DECIMAL UNSIGNED", false}, "DECIMAL", -1},
-	{{"FIXED", false}, "DECIMAL", -1},
-	{{"FIXED UNSIGNED", false}, "DECIMAL", -1},
-	{{"BIT(1)", false}, "BOOLEAN", 0},
-	{{"BIT", false}, "BIT", -1},
-	{{"BOOL", false}, "BOOLEAN", -1},
-	{{"DOUBLE", false}, "DOUBLE PRECISION", 0},
-	{{"DOUBLE PRECISION", false}, "DOUBLE PRECISION", 0},
-	{{"DOUBLE PRECISION UNSIGNED", false}, "DOUBLE PRECISION", 0},
-	{{"DOUBLE UNSIGNED", false}, "DOUBLE PRECISION", 0},
-	{{"REAL", false}, "REAL", 0},
-	{{"REAL UNSIGNED", false}, "REAL", 0},
-	{{"FLOAT", false}, "REAL", 0},
-	{{"FLOAT UNSIGNED", false}, "REAL", 0},
-	{{"INT", false}, "INT", 0},
-	{{"INT UNSIGNED", false}, "BIGINT", 0},
-	{{"INTEGER", false}, "INT", 0},
-	{{"INTEGER UNSIGNED", false}, "BIGINT", 0},
-	{{"MEDIUMINT", false}, "INT", 0},
-	{{"MEDIUMINT UNSIGNED", false}, "INT", 0},
-	{{"YEAR", false}, "INT", 0},
-	{{"SMALLINT", false}, "SMALLINT", 0},
-	{{"SMALLINT UNSIGNED", false}, "INT", 0},
-	{{"TINYINT", false}, "SMALLINT", 0},
-	{{"TINYINT UNSIGNED", false}, "SMALLINT", 0},
-	{{"DATETIME", false}, "TIMESTAMP", -1},
-	{{"TIMESTAMP", false}, "TIMESTAMPTZ", -1},
-	{{"BINARY", false}, "BYTEA", 0},
-	{{"VARBINARY", false}, "BYTEA", 0},
-	{{"BLOB", false}, "BYTEA", 0},
-	{{"MEDIUMBLOB", false}, "BYTEA", 0},
-	{{"LONGBLOB", false}, "BYTEA", 0},
-	{{"TINYBLOB", false}, "BYTEA", 0},
-	{{"LONG VARCHAR", false}, "TEXT", -1},
-	{{"LONGTEXT", false}, "TEXT", -1},
-	{{"MEDIUMTEXT", false}, "TEXT", -1},
-	{{"TINYTEXT", false}, "TEXT", -1},
-	{{"JSON", false}, "JSONB", -1},
-	/* spatial types - map to TEXT by default */
-	{{"GEOMETRY", false}, "TEXT", -1},
-	{{"GEOMETRYCOLLECTION", false}, "TEXT", -1},
-	{{"GEOMCOLLECTION", false}, "TEXT", -1},
-	{{"LINESTRING", false}, "TEXT", -1},
-	{{"MULTILINESTRING", false}, "TEXT", -1},
-	{{"MULTIPOINT", false}, "TEXT", -1},
-	{{"MULTIPOLYGON", false}, "TEXT", -1},
-	{{"POINT", false}, "TEXT", -1},
-	{{"POLYGON", false}, "TEXT", -1}
+	{{"int", true}, "serial", 0},
+	{{"bigint", true}, "bigserial", 0},
+	{{"smallint", true}, "smallserial", 0},
+	{{"mediumint", true}, "serial", 0},
+	{{"enum", false}, "text", 0},
+	{{"set", false}, "text", 0},
+	{{"bigint", false}, "bigint", 0},
+	{{"bigint unsigned", false}, "numeric", -1},
+	{{"numeric unsigned", false}, "numeric", -1},
+	{{"dec", false}, "decimal", -1},
+	{{"dec unsigned", false}, "decimal", -1},
+	{{"decimal unsigned", false}, "decimal", -1},
+	{{"fixed", false}, "decimal", -1},
+	{{"fixed unsigned", false}, "decimal", -1},
+	{{"bit(1)", false}, "boolean", 0},
+	{{"bit", false}, "bit", -1},
+	{{"bool", false}, "boolean", -1},
+	{{"double", false}, "double precision", 0},
+	{{"double precision", false}, "double precision", 0},
+	{{"double precision unsigned", false}, "double precision", 0},
+	{{"double unsigned", false}, "double precision", 0},
+	{{"real", false}, "real", 0},
+	{{"real unsigned", false}, "real", 0},
+	{{"float", false}, "real", 0},
+	{{"float unsigned", false}, "real", 0},
+	{{"int", false}, "int", 0},
+	{{"int unsigned", false}, "bigint", 0},
+	{{"integer", false}, "int", 0},
+	{{"integer unsigned", false}, "bigint", 0},
+	{{"mediumint", false}, "int", 0},
+	{{"mediumint unsigned", false}, "int", 0},
+	{{"year", false}, "int", 0},
+	{{"smallint", false}, "smallint", 0},
+	{{"smallint unsigned", false}, "int", 0},
+	{{"tinyint", false}, "smallint", 0},
+	{{"tinyint unsigned", false}, "smallint", 0},
+	{{"datetime", false}, "timestamp", -1},
+	{{"timestamp", false}, "timestamptz", -1},
+	{{"binary", false}, "bytea", 0},
+	{{"varbinary", false}, "bytea", 0},
+	{{"blob", false}, "bytea", 0},
+	{{"mediumblob", false}, "bytea", 0},
+	{{"longblob", false}, "bytea", 0},
+	{{"tinyblob", false}, "bytea", 0},
+	{{"long varchar", false}, "text", -1},
+	{{"longtext", false}, "text", -1},
+	{{"mediumtext", false}, "text", -1},
+	{{"tinytext", false}, "text", -1},
+	{{"json", false}, "jsonb", -1},
+	/* spatial types - map to text by default */
+	{{"geometry", false}, "text", -1},
+	{{"geometrycollection", false}, "text", -1},
+	{{"geomcollection", false}, "text", -1},
+	{{"linestring", false}, "text", -1},
+	{{"multilinestring", false}, "text", -1},
+	{{"multipoint", false}, "text", -1},
+	{{"multipolygon", false}, "text", -1},
+	{{"point", false}, "text", -1},
+	{{"polygon", false}, "text", -1}
 };
 #define SIZE_MYSQL_DATATYPE_MAPPING (sizeof(mysql_defaultTypeMappings) / sizeof(DatatypeHashEntry))
 
 DatatypeHashEntry oracle_defaultTypeMappings[] =
 {
-	{{"BINARY_DOUBLE", false}, "DOUBLE PRECISION", 0},
-	{{"BINARY_FLOAT", false}, "REAL", 0},
-	{{"FLOAT", false}, "REAL", 0},
-	{{"NUMBER(0,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(1,0)", false}, "SMALLINT", 0},
-	{{"NUMBER(2,0)", false}, "SMALLINT", 0},
-	{{"NUMBER(3,0)", false}, "SMALLINT", 0},
-	{{"NUMBER(4,0)", false}, "SMALLINT", 0},
-	{{"NUMBER(5,0)", false}, "INT", 0},
-	{{"NUMBER(6,0)", false}, "INT", 0},
-	{{"NUMBER(7,0)", false}, "INT", 0},
-	{{"NUMBER(8,0)", false}, "INT", 0},
-	{{"NUMBER(9,0)", false}, "INT", 0},
-	{{"NUMBER(10,0)", false}, "BIGINT", 0},
-	{{"NUMBER(11,0)", false}, "BIGINT", 0},
-	{{"NUMBER(12,0)", false}, "BIGINT", 0},
-	{{"NUMBER(13,0)", false}, "BIGINT", 0},
-	{{"NUMBER(14,0)", false}, "BIGINT", 0},
-	{{"NUMBER(15,0)", false}, "BIGINT", 0},
-	{{"NUMBER(16,0)", false}, "BIGINT", 0},
-	{{"NUMBER(17,0)", false}, "BIGINT", 0},
-	{{"NUMBER(18,0)", false}, "BIGINT", 0},
-	{{"NUMBER(19,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(20,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(21,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(22,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(23,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(24,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(25,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(26,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(27,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(28,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(29,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(30,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(31,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(32,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(33,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(34,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(35,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(36,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(37,0)", false}, "NUMERIC", -1},
-	{{"NUMBER(38,0)", false}, "NUMERIC", -1},
-	{{"NUMBER", false}, "NUMERIC", -1},
-	{{"NUMERIC", false}, "NUMERIC", -1},
-	{{"DATE", false}, "TIMESTAMP", -1},
-	{{"LONG", false}, "TEXT", -1},
-	{{"INTERVAL DAY TO SECOND", false}, "INTERVAL DAY TO SECOND", -1},
-	{{"INTERVAL YEAR TO MONTH", false}, "INTERVAL YEAR TO MONTH", 0},
-	{{"TIMESTAMP", false}, "TIMESTAMP", -1},
-	{{"TIMESTAMP WITH LOCAL TIME ZONE", false}, "TIMESTAMPTZ", -1},
-	{{"TIMESTAMP WITH TIME ZONE", false}, "TIMESTAMPTZ", -1},
-	{{"DATE", false}, "DATE", -1},
-	{{"CHAR", false}, "CHAR", -1},
-	{{"NCHAR", false}, "CHAR", -1},
-	{{"NVARCHAR2", false}, "VARCHAR", -1},
-	{{"VARCHAR", false}, "VARCHAR", -1},
-	{{"VARCHAR2", false}, "VARCHAR", -1},
-	{{"LONG RAW", false}, "BYTEA", 0},
-	{{"RAW", false}, "BYTEA", 0},
-	{{"DECIMAL", false}, "DECIMAL", -1},
-	{{"ROWID", false}, "TEXT", 0},
-	{{"UROWID", false}, "TEXT", 0},
-	{{"XMLTYPE", false}, "TEXT", 0},
-	/* Large objects */
-	{{"BFILE", false}, "TEXT", 0},
-	{{"BLOB", false}, "BYTEA", 0},
-	{{"CLOB", false}, "TEXT", 0},
-	{{"NCLOB", false}, "TEXT", 0}
+	{{"binary_double", false}, "double precision", 0},
+	{{"binary_float", false}, "real", 0},
+	{{"float", false}, "real", 0},
+	{{"number(0,0)", false}, "numeric", -1},
+	{{"number(1,0)", false}, "smallint", 0},
+	{{"number(2,0)", false}, "smallint", 0},
+	{{"number(3,0)", false}, "smallint", 0},
+	{{"number(4,0)", false}, "smallint", 0},
+	{{"number(5,0)", false}, "int", 0},
+	{{"number(6,0)", false}, "int", 0},
+	{{"number(7,0)", false}, "int", 0},
+	{{"number(8,0)", false}, "int", 0},
+	{{"number(9,0)", false}, "int", 0},
+	{{"number(10,0)", false}, "bigint", 0},
+	{{"number(11,0)", false}, "bigint", 0},
+	{{"number(12,0)", false}, "bigint", 0},
+	{{"number(13,0)", false}, "bigint", 0},
+	{{"number(14,0)", false}, "bigint", 0},
+	{{"number(15,0)", false}, "bigint", 0},
+	{{"number(16,0)", false}, "bigint", 0},
+	{{"number(17,0)", false}, "bigint", 0},
+	{{"number(18,0)", false}, "bigint", 0},
+	{{"number(19,0)", false}, "numeric", -1},
+	{{"number(20,0)", false}, "numeric", -1},
+	{{"number(21,0)", false}, "numeric", -1},
+	{{"number(22,0)", false}, "numeric", -1},
+	{{"number(23,0)", false}, "numeric", -1},
+	{{"number(24,0)", false}, "numeric", -1},
+	{{"number(25,0)", false}, "numeric", -1},
+	{{"number(26,0)", false}, "numeric", -1},
+	{{"number(27,0)", false}, "numeric", -1},
+	{{"number(28,0)", false}, "numeric", -1},
+	{{"number(29,0)", false}, "numeric", -1},
+	{{"number(30,0)", false}, "numeric", -1},
+	{{"number(31,0)", false}, "numeric", -1},
+	{{"number(32,0)", false}, "numeric", -1},
+	{{"number(33,0)", false}, "numeric", -1},
+	{{"number(34,0)", false}, "numeric", -1},
+	{{"number(35,0)", false}, "numeric", -1},
+	{{"number(36,0)", false}, "numeric", -1},
+	{{"number(37,0)", false}, "numeric", -1},
+	{{"number(38,0)", false}, "numeric", -1},
+	{{"number", false}, "numeric", -1},
+	{{"numeric", false}, "numeric", -1},
+	{{"date", false}, "timestamp", -1},
+	{{"long", false}, "text", -1},
+	{{"interval day to second", false}, "interval day to second", -1},
+	{{"interval year to month", false}, "interval year to month", 0},
+	{{"timestamp", false}, "timestamp", -1},
+	{{"timestamp with local time zone", false}, "timestamptz", -1},
+	{{"timestamp with time zone", false}, "timestamptz", -1},
+	{{"date", false}, "date", -1},
+	{{"char", false}, "char", -1},
+	{{"nchar", false}, "char", -1},
+	{{"nvarchar2", false}, "varchar", -1},
+	{{"varchar", false}, "varchar", -1},
+	{{"varchar2", false}, "varchar", -1},
+	{{"long raw", false}, "bytea", 0},
+	{{"raw", false}, "bytea", 0},
+	{{"decimal", false}, "decimal", -1},
+	{{"rowid", false}, "text", 0},
+	{{"urowid", false}, "text", 0},
+	{{"xmltype", false}, "text", 0},
+	/* large objects */
+	{{"bfile", false}, "text", 0},
+	{{"blob", false}, "bytea", 0},
+	{{"clob", false}, "text", 0},
+	{{"nclob", false}, "text", 0}
 };
 #define SIZE_ORACLE_DATATYPE_MAPPING (sizeof(oracle_defaultTypeMappings) / sizeof(DatatypeHashEntry))
 
 DatatypeHashEntry sqlserver_defaultTypeMappings[] =
 {
-	{{"int identity", true}, "SERIAL", 0},
-	{{"bigint identity", true}, "BIGSERIAL", 0},
-	{{"smallint identity", true}, "SMALLSERIAL", 0},
-	{{"enum", false}, "TEXT", 0},
-	{{"int", false}, "INT", 0},
-	{{"bigint", false}, "BIGINT", 0},
-	{{"smallint", false}, "SMALLINT", 0},
-	{{"tinyint", false}, "SMALLINT", 0},
-	{{"numeric", false}, "NUMERIC", 0},
-	{{"decimal", false}, "NUMERIC", 0},
-	{{"bit(1)", false}, "BOOL", 0},
-	{{"bit", false}, "BIT", 0},
-	{{"money", false}, "MONEY", 0},
-	{{"smallmoney", false}, "MONEY", 0},
-	{{"real", false}, "REAL", 0},
-	{{"float", false}, "REAL", 0},
-	{{"date", false}, "DATE", 0},
-	{{"time", false}, "TIME", 0},
-	{{"datetime", false}, "TIMESTAMP", 0},
-	{{"datetime2", false}, "TIMESTAMP", 0},
-	{{"datetimeoffset", false}, "TIMESTAMPTZ", 0},
-	{{"smalldatetime", false}, "TIMESTAMP", 0},
-	{{"char", false}, "CHAR", -1},
-	{{"varchar", false}, "VARCHAR", -1},
-	{{"text", false}, "TEXT", 0},
-	{{"nchar", false}, "CHAR", 0},
-	{{"nvarchar", false}, "VARCHAR", -1},
-	{{"ntext", false}, "TEXT", 0},
-	{{"binary", false}, "BYTEA", 0},
-	{{"varbinary", false}, "BYTEA", 0},
-	{{"image", false}, "BYTEA", 0},
-	{{"uniqueidentifier", false}, "UUID", 0},
-	{{"xml", false}, "TEXT", 0},
-	/* spatial types - map to TEXT by default */
-	{{"geometry", false}, "TEXT", 0},
-	{{"geography", false}, "TEXT", 0},
+	{{"int identity", true}, "serial", 0},
+	{{"bigint identity", true}, "bigserial", 0},
+	{{"smallint identity", true}, "smallserial", 0},
+	{{"enum", false}, "text", 0},
+	{{"int", false}, "int", 0},
+	{{"bigint", false}, "bigint", 0},
+	{{"smallint", false}, "smallint", 0},
+	{{"tinyint", false}, "smallint", 0},
+	{{"numeric", false}, "numeric", 0},
+	{{"decimal", false}, "numeric", 0},
+	{{"bit(1)", false}, "bool", 0},
+	{{"bit", false}, "bit", 0},
+	{{"money", false}, "money", 0},
+	{{"smallmoney", false}, "money", 0},
+	{{"real", false}, "real", 0},
+	{{"float", false}, "real", 0},
+	{{"date", false}, "date", 0},
+	{{"time", false}, "time", 0},
+	{{"datetime", false}, "timestamp", 0},
+	{{"datetime2", false}, "timestamp", 0},
+	{{"datetimeoffset", false}, "timestamptz", 0},
+	{{"smalldatetime", false}, "timestamp", 0},
+	{{"char", false}, "char", -1},
+	{{"varchar", false}, "varchar", -1},
+	{{"text", false}, "text", 0},
+	{{"nchar", false}, "char", 0},
+	{{"nvarchar", false}, "varchar", -1},
+	{{"ntext", false}, "text", 0},
+	{{"binary", false}, "bytea", 0},
+	{{"varbinary", false}, "bytea", 0},
+	{{"image", false}, "bytea", 0},
+	{{"uniqueidentifier", false}, "uuid", 0},
+	{{"xml", false}, "text", 0},
+	/* spatial types - map to text by default */
+	{{"geometry", false}, "text", 0},
+	{{"geography", false}, "text", 0},
 };
 
 #define SIZE_SQLSERVER_DATATYPE_MAPPING (sizeof(sqlserver_defaultTypeMappings) / sizeof(DatatypeHashEntry))
@@ -494,7 +494,7 @@ remove_double_quotes(StringInfoData * str)
  *
  * escape the single quotes in the given input and returns a palloc-ed string
  */
-static char *
+char *
 escapeSingleQuote(const char * in, bool addquote)
 {
 	int i = 0, j = 0, outlen = 0;
@@ -1335,8 +1335,13 @@ parseDBZDDL(Jsonb * jb)
 				{
 					if (!strcmp(key, "name"))
 					{
+						int j = 0;
 						elog(DEBUG1, "consuming %s = %s", key, value);
 						ddlcol->name = pstrdup(value);
+
+						/* convert typeName to lowercase for consistency */
+						for (j = 0; j < strlen(ddlcol->name); j++)
+							ddlcol->name[j] = (char) pg_tolower(ddlcol->name[j]);
 					}
 					if (!strcmp(key, "length"))
 					{
@@ -1355,8 +1360,13 @@ parseDBZDDL(Jsonb * jb)
 					}
 					if (!strcmp(key, "typeName"))
 					{
+						int j = 0;
 						elog(DEBUG1, "consuming %s = %s", key, value);
 						ddlcol->typeName = pstrdup(value);
+
+						/* convert typeName to lowercase for consistency */
+						for (j = 0; j < strlen(ddlcol->typeName); j++)
+							ddlcol->typeName[j] = (char) pg_tolower(ddlcol->typeName[j]);
 					}
 					if (!strcmp(key, "enumValues"))
 					{
@@ -1512,22 +1522,10 @@ transformDDLColumns(const char * id, DBZ_DDL_COLUMN * col, ConnectorType conntyp
 
 			/*
 			 * check if there is a translation rule applied specifically for this column using
-			 * key format: [column object id].[data type]
+			 * key format: [column object id]
 			 */
-			if (!strcasecmp(col->typeName, "BIT") && col->length == 1)
-			{
-				/* special lookup case: BIT with length 1 */
-				key.autoIncremented = col->autoIncremented;
-				snprintf(key.extTypeName, sizeof(key.extTypeName), "%s.%s(%d)",
-						colNameObjId.data, col->typeName, col->length);
-			}
-			else
-			{
-				/* all other cases - no special handling */
-				key.autoIncremented = col->autoIncremented;
-				snprintf(key.extTypeName, sizeof(key.extTypeName), "%s.%s",
-						colNameObjId.data, col->typeName);
-			}
+			key.autoIncremented = col->autoIncremented;
+			snprintf(key.extTypeName, sizeof(key.extTypeName), "%s", colNameObjId.data);
 
 			entry = (DatatypeHashEntry *) hash_search(mysqlDatatypeHash, &key, HASH_FIND, &found);
 			if (!found)
@@ -1537,7 +1535,7 @@ transformDDLColumns(const char * id, DBZ_DDL_COLUMN * col, ConnectorType conntyp
 				 * Now, check if there is a global data type translation rule
 				 */
 				memset(&key, 0, sizeof(DatatypeHashKey));
-				if (!strcasecmp(col->typeName, "BIT") && col->length == 1)
+				if (!strcasecmp(col->typeName, "bit") && col->length == 1)
 				{
 					/* special lookup case: BIT with length 1 */
 					key.autoIncremented = col->autoIncremented;
@@ -1617,32 +1615,14 @@ transformDDLColumns(const char * id, DBZ_DDL_COLUMN * col, ConnectorType conntyp
 			 * we need to make size = scale, and empty the scale to maintain compatibility in
 			 * PostgreSQL.
 			 */
-			if ((!strcasecmp(col->typeName, "INTERVAL DAY TO SECOND") && col->scale > 0) || removed)
+			if ((!strcasecmp(col->typeName, "interval day to second") && col->scale > 0) || removed)
 			{
 				col->length = col->scale;
 				col->scale = 0;
 			}
 
-			if (!strcasecmp(col->typeName, "NUMBER") && col->scale == 0)
-			{
-				/*
-				 * special case: variable length NUMBER value - re-structure col->typeName so that
-				 * it includes length and precision information before we do any data type mapping
-				 * lookup. This ensures a more granular mappings. We only do this when col->scale
-				 * is zero because it indicates an integer type, and PostgreSQL has different int
-				 * types for different sizes.
-				 */
-				key.autoIncremented = col->autoIncremented;
-				snprintf(key.extTypeName, sizeof(key.extTypeName), "%s.%s(%d,%d)",
-						colNameObjId.data, col->typeName, col->length, col->scale);
-			}
-			else
-			{
-				/* all other cases - no special handling */
-				key.autoIncremented = col->autoIncremented;
-				snprintf(key.extTypeName, sizeof(key.extTypeName), "%s.%s",
-						colNameObjId.data, col->typeName);
-			}
+			key.autoIncremented = col->autoIncremented;
+			snprintf(key.extTypeName, sizeof(key.extTypeName), "%s",colNameObjId.data);
 
 			entry = (DatatypeHashEntry *) hash_search(oracleDatatypeHash, &key, HASH_FIND, &found);
 			if (!found)
@@ -1652,7 +1632,7 @@ transformDDLColumns(const char * id, DBZ_DDL_COLUMN * col, ConnectorType conntyp
 				 * Now, check if there is a global data type translation rule
 				 */
 				memset(&key, 0, sizeof(DatatypeHashKey));
-				if (!strcasecmp(col->typeName, "NUMBER") && col->scale == 0)
+				if (!strcasecmp(col->typeName, "number") && col->scale == 0)
 				{
 					/*
 					 * special case: variable length NUMBER value - re-structure col->typeName so that
@@ -1728,22 +1708,10 @@ transformDDLColumns(const char * id, DBZ_DDL_COLUMN * col, ConnectorType conntyp
 
 			/*
 			 * check if there is a translation rule applied specifically for this column using
-			 * key format: [column object id].[data type]
+			 * key format: [column object id]
 			 */
-			if (!strcasecmp(col->typeName, "bit") && col->length == 1)
-			{
-				/* special lookup case: BIT with length 1 */
-				key.autoIncremented = col->autoIncremented;
-				snprintf(key.extTypeName, sizeof(key.extTypeName), "%s.%s(%d)",
-						colNameObjId.data, col->typeName, col->length);
-			}
-			else
-			{
-				/* all other cases - no special handling */
-				key.autoIncremented = col->autoIncremented;
-				snprintf(key.extTypeName, sizeof(key.extTypeName), "%s.%s",
-						colNameObjId.data, col->typeName);
-			}
+			key.autoIncremented = col->autoIncremented;
+			snprintf(key.extTypeName, sizeof(key.extTypeName), "%s", colNameObjId.data);
 
 			entry = (DatatypeHashEntry *) hash_search(sqlserverDatatypeHash, &key, HASH_FIND, &found);
 			if (!found)
@@ -1818,9 +1786,9 @@ transformDDLColumns(const char * id, DBZ_DDL_COLUMN * col, ConnectorType conntyp
 			 * and time date types are sent as "scale" not as "length" as in
 			 * mysql case. So we need to use the scale value here
 			 */
-			if (col->scale > 0 && (find_exact_string_match(entry->pgsqlTypeName, "TIMESTAMP") ||
-					find_exact_string_match(entry->pgsqlTypeName, "TIME") ||
-					find_exact_string_match(entry->pgsqlTypeName, "TIMESTAMPTZ")))
+			if (col->scale > 0 && (find_exact_string_match(entry->pgsqlTypeName, "timestamp") ||
+					find_exact_string_match(entry->pgsqlTypeName, "time") ||
+					find_exact_string_match(entry->pgsqlTypeName, "timestamptz")))
 			{
 				/* postgresql can only support up to 6 */
 				if (col->scale > 6)
@@ -2123,7 +2091,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			}
 
 			/* if there is UNSIGNED operator found in col->typeName, add CHECK constraint */
-			if (strstr(col->typeName, "UNSIGNED"))
+			if (strstr(col->typeName, "unsigned"))
 			{
 				appendStringInfo(&strinfo, "CHECK (%s >= 0) ", col->name);
 			}
@@ -2431,7 +2399,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 					}
 
 					/* if there is UNSIGNED operator found in col->typeName, add CHECK constraint */
-					if (strstr(col->typeName, "UNSIGNED"))
+					if (strstr(col->typeName, "unsigned"))
 					{
 						appendStringInfo(&strinfo, "CHECK (%s >= 0) ", pgcol->attname);
 					}
@@ -3313,9 +3281,6 @@ processDataByType(DBZ_DML_COLUMN_VALUE * colval, bool addquote, char * remoteObj
 			 * is number-oriented, and with addquote=true, it will produce the number
 			 * in quotes which may not be desirable.
 			 */
-			elog(WARNING,"no special handling for data type %d, treat it as text",
-					colval->datatype);
-
 			if (addquote)
 			{
 				out = escapeSingleQuote(in, addquote);
@@ -4905,11 +4870,7 @@ updateSynchdbAttribute(DBZ_DDL * dbzddl, PG_DDL * pgddl, ConnectorType conntype,
 			!strcmp(pgddl->type, "ALTER"))
 	{
 		int j = 0;
-		bool found = false;
 		Oid schemaoid, tableoid;
-		TransformExpressionHashEntry * entry = NULL;
-		TransformExpressionHashKey key = {0};
-		char * expression = NULL;
 
 		if (list_length(dbzddl->columns) <= 0 || list_length(pgddl->columns) <= 0)
 		{
@@ -4947,7 +4908,7 @@ updateSynchdbAttribute(DBZ_DDL * dbzddl, PG_DDL * pgddl, ConnectorType conntype,
 		}
 
 		appendStringInfo(&strinfo, "INSERT INTO %s (name, type, attrelid, attnum, "
-				"ext_tbname, ext_attname, ext_atttypename, transform) VALUES ",
+				"ext_tbname, ext_attname, ext_atttypename) VALUES ",
 				SYNCHDB_ATTRIBUTE_TABLE);
 
 		forboth(cell, dbzddl->columns, cell2, pgddl->columns)
@@ -4958,36 +4919,14 @@ updateSynchdbAttribute(DBZ_DDL * dbzddl, PG_DDL * pgddl, ConnectorType conntype,
 			if (pgcol->attname == NULL || pgcol->atttype == NULL)
 				continue;
 
-			/* get the transform expression of this column data if exists */
-			if (transformExpressionHash)
-			{
-				snprintf(key.extObjName, sizeof(key.extObjName), "%s.%s", dbzddl->id, col->name);
-				entry = (TransformExpressionHashEntry *) hash_search(transformExpressionHash, &key, HASH_FIND, &found);
-				if (!found)
-				{
-					elog(DEBUG1, "no data transformation needed for %s", key.extObjName);
-					expression = NULL;
-				}
-				else
-				{
-					/* return the expression to run */
-					elog(DEBUG1, "%s needs data transformation with expression '%s'",
-							key.extObjName, entry->pgsqlTransExpress);
-					expression = escapeSingleQuote(entry->pgsqlTransExpress, true);
-				}
-			}
-			else
-				expression = NULL;
-
-			appendStringInfo(&strinfo, "(lower('%s'),lower('%s'),%d,%d,'%s','%s','%s', %s),",
+			appendStringInfo(&strinfo, "(lower('%s'),lower('%s'),%d,%d,'%s','%s','%s'),",
 					name,
 					connectorTypeToString(conntype),
 					tableoid,
 					pgcol->position,
 					dbzddl->id,
 					col->name,
-					col->typeName,
-					expression == NULL ? "null" : expression);
+					col->typeName);
 		}
 		/* remove extra "," */
 		strinfo.data[strinfo.len - 1] = '\0';
@@ -4997,8 +4936,7 @@ updateSynchdbAttribute(DBZ_DDL * dbzddl, PG_DDL * pgddl, ConnectorType conntype,
 				"DO UPDATE SET "
 				"ext_tbname = EXCLUDED.ext_tbname,"
 				"ext_attname = EXCLUDED.ext_attname,"
-				"ext_atttypename = EXCLUDED.ext_atttypename,"
-				"transform = EXCLUDED.transform; ");
+				"ext_atttypename = EXCLUDED.ext_atttypename;");
 	}
 	else if (!strcmp(pgddl->type, "DROP"))
 	{
@@ -5044,6 +4982,128 @@ updateSynchdbAttribute(DBZ_DDL * dbzddl, PG_DDL * pgddl, ConnectorType conntype,
 	ra_executeCommand(strinfo.data);
 }
 
+static int
+alter_tbname(const char * from, const char * to)
+{
+	/* work on copies of the inputs */
+	char * fromcopy = pstrdup(from);
+	char * tocopy = pstrdup(to);
+	char * db = NULL, * schema = NULL, * table = NULL;
+	char * db2 = NULL, * schema2 = NULL, * table2 = NULL;
+	StringInfoData strinfo;
+	int ret = -1;
+
+	if (!from || !to)
+		return ret;
+
+	initStringInfo(&strinfo);
+	splitIdString(fromcopy, &db, &schema, &table, false);
+	if (table && schema)
+	{
+		/* 'from' expressed as schema.table */
+		splitIdString(tocopy, &db2, &schema2, &table2, false);
+		if (table2 && schema2)
+		{
+			/* 'to' expressed as schema.table */
+			appendStringInfo(&strinfo, "CREATE SCHEMA IF NOT EXISTS %s; "
+					"ALTER TABLE %s RENAME TO %s; "
+					"ALTER TABLE %s.%s SET SCHEMA %s;",
+					schema2, from, table2, schema, table2, schema2);
+		}
+		else
+		{
+			/* 'to' expressed as table */
+			appendStringInfo(&strinfo, "ALTER TABLE %s RENAME TO %s;"
+					"ALTER TABLE %s.%s SET SCHEMA public;",
+					from, table2, schema, table2);
+		}
+	}
+	else
+	{
+		/* 'from' expressed as table */
+		splitIdString(tocopy, &db2, &schema2, &table2, false);
+		if (table2 && schema2)
+		{
+			/* 'to' expressed as schema.table */
+			appendStringInfo(&strinfo, "CREATE SCHEMA IF NOT EXISTS %s; "
+					"ALTER TABLE %s RENAME TO %s; "
+					"ALTER TABLE %s SET SCHEMA %s;",
+					schema2, from, table2, table2, schema2);
+		}
+		else
+		{
+			/* 'to' expressed as table */
+			appendStringInfo(&strinfo, "ALTER TABLE %s RENAME TO %s;",
+					from, table2);
+		}
+	}
+
+	elog(WARNING, "renaming table from '%s' to '%s' with query: %s", from, to, strinfo.data);
+	ret = ra_executeCommand(strinfo.data);
+
+	pfree(fromcopy);
+	pfree(tocopy);
+	if (strinfo.data)
+		pfree(strinfo.data);
+
+	return ret;
+}
+
+static int
+alter_attname(const char * tbname, const char * from, const char * to)
+{
+	int ret = -1;
+	StringInfoData strinfo;
+
+	if (!tbname || !from || !to)
+		return ret;
+
+	initStringInfo(&strinfo);
+	appendStringInfo(&strinfo, "ALTER TABLE %s RENAME COLUMN %s TO %s;",
+			tbname, from, to);
+
+	elog(WARNING, "renaming table ('%s')'s column from '%s' to '%s' with query: %s",
+			tbname, from, to, strinfo.data);
+	ret = ra_executeCommand(strinfo.data);
+
+	if (strinfo.data)
+		pfree(strinfo.data);
+
+	return ret;
+}
+
+static int
+alter_atttype(const char * tbname, const char * from, const char * to, int typesz, const char * convertfunc)
+{
+	int ret = -1;
+	StringInfoData strinfo;
+
+	if (!tbname || !from || !to)
+		return ret;
+
+	initStringInfo(&strinfo);
+	appendStringInfo(&strinfo, "ALTER TABLE %s ALTER COLUMN %s SET DATA TYPE %s",
+			tbname, from, to);
+
+	if (typesz > 0)
+	{
+		appendStringInfo(&strinfo, "(%d)", typesz);
+	}
+
+	if (convertfunc)
+		appendStringInfo(&strinfo, " USING %s::%s;", tbname, convertfunc);
+	else
+		appendStringInfo(&strinfo, ";");
+
+	elog(WARNING, "alter data type for table ('%s') column ('%s') to '%s' with query: %s",
+			tbname, from, to, strinfo.data);
+	ret = ra_executeCommand(strinfo.data);
+
+	if (strinfo.data)
+		pfree(strinfo.data);
+
+	return ret;
+}
 /*
  * fc_initFormatConverter
  *
@@ -5577,6 +5637,234 @@ fc_load_rules(ConnectorType connectorType, const char * rulefile)
 	return true;
 }
 
+bool
+fc_load_objmap(const char * name, ConnectorType connectorType)
+{
+	ObjectMap * objs = NULL;
+	int numobjs = 0;
+	int ret = -1;
+	int i = 0;
+	bool found = false;
+	ObjMapHashEntry objmapentry = {0};
+	ObjMapHashEntry * objmaplookup;
+	HASHCTL	info;
+	HTAB * rulehash = NULL;
+	DatatypeHashEntry hashentry;
+	DatatypeHashEntry * entrylookup;
+
+	TransformExpressionHashEntry expressentry;
+	TransformExpressionHashEntry * expressentrylookup;
+
+	switch (connectorType)
+	{
+		case TYPE_MYSQL:
+			rulehash = mysqlDatatypeHash;
+			break;
+		case TYPE_ORACLE:
+			rulehash = oracleDatatypeHash;
+			break;
+		case TYPE_SQLSERVER:
+			rulehash = sqlserverDatatypeHash;
+			break;
+		default:
+		{
+			set_shm_connector_errmsg(myConnectorId, "unsupported connector type");
+			elog(ERROR, "unsupported connector type");
+		}
+	}
+
+	if (!rulehash)
+	{
+		set_shm_connector_errmsg(myConnectorId, "data type hash not initialized");
+		elog(ERROR, "data type hash not initialized");
+	}
+
+	ret = ra_listObjmaps(name, &objs, &numobjs);
+	if (ret)
+	{
+		elog(WARNING, "no object mapping rules found for connector '%s'", name);
+		return true;
+	}
+
+	for (i = 0; i < numobjs; i++)
+	{
+		elog(DEBUG1, "type %s, src %s dst %s: (%s) (%s)", objs[i].objtype, objs[i].srcobj, objs[i].dstobj,
+				objs[i].curr_pg_tbname, objs[i].curr_pg_attname);
+		/* initialized objectMappingHash if not done yet */
+
+		if (!strcasecmp(objs[i].objtype, "table") || !strcasecmp(objs[i].objtype, "column") )
+		{
+			if (!objectMappingHash)
+			{
+				info.keysize = sizeof(ObjMapHashKey);
+				info.entrysize = sizeof(ObjMapHashEntry);
+				info.hcxt = CurrentMemoryContext;
+				objectMappingHash = hash_create("object mapping hash",
+												 256,
+												 &info,
+												 HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+			}
+
+			memset(&objmapentry, 0, sizeof(ObjMapHashEntry));
+
+			strlcpy(objmapentry.key.extObjType, objs[i].objtype, SYNCHDB_OBJ_TYPE_SIZE);
+			strlcpy(objmapentry.key.extObjName, objs[i].srcobj, SYNCHDB_OBJ_NAME_SIZE);
+			strlcpy(objmapentry.pgsqlObjName, objs[i].dstobj, SYNCHDB_OBJ_NAME_SIZE);
+
+			objmaplookup = (ObjMapHashEntry *) hash_search(objectMappingHash,
+					&(objmapentry.key), HASH_ENTER, &found);
+
+			/* found or not, just update or insert it */
+			memset(objmaplookup->key.extObjName, 0, SYNCHDB_OBJ_NAME_SIZE);
+			strlcpy(objmaplookup->key.extObjName,
+					objmapentry.key.extObjName,
+					SYNCHDB_OBJ_NAME_SIZE);
+
+			memset(objmaplookup->pgsqlObjName, 0, SYNCHDB_OBJ_NAME_SIZE);
+			strlcpy(objmaplookup->pgsqlObjName,
+					objmapentry.pgsqlObjName,
+					SYNCHDB_OBJ_NAME_SIZE);
+
+			elog(WARNING, "Inserted / updated object mapping '%s(%s)' <-> '%s'", objmaplookup->key.extObjName,
+					objmapentry.key.extObjType, objmaplookup->pgsqlObjName);
+
+			/*
+			 * if this is a table object mapping and that the connector has already created a matching table
+			 * in PostgreSQL, we need to check if the mapped table is the same as the one created. If not
+			 * then the user is requesting to rename the table.
+			 */
+			if (!strcasecmp(objs[i].objtype, "table") && objs[i].curr_pg_tbname[0] != '\0')
+			{
+				/* if dstobj contains no dot(no schema info), we will default to public schema */
+				if (strchr(objs[i].dstobj, '.') == NULL)
+				{
+					char temp[SYNCHDB_TRANSFORM_EXPRESSION_SIZE];
+					strlcpy(temp, objs[i].dstobj, SYNCHDB_TRANSFORM_EXPRESSION_SIZE);
+
+					snprintf(&objs[i].dstobj[0], SYNCHDB_TRANSFORM_EXPRESSION_SIZE, "public.%s", temp);
+				}
+
+				if (strcasecmp(objs[i].dstobj, objs[i].curr_pg_tbname))
+				{
+					alter_tbname(objs[i].curr_pg_tbname, objs[i].dstobj);
+				}
+			}
+
+			/*
+			 * if this is a column object mapping and that the connector has already created a matching table
+			 * in PostgreSQL, we need to check if the mapped column is the same as the one created. If not
+			 * then the user is requesting to rename the column.
+			 */
+			if (!strcasecmp(objs[i].objtype, "column") && objs[i].curr_pg_attname[0] != '\0' && objs[i].curr_pg_tbname[0] != '\0')
+			{
+				if (strcasecmp(objs[i].dstobj, objs[i].curr_pg_attname))
+				{
+					alter_attname(objs[i].curr_pg_tbname, objs[i].curr_pg_attname, objs[i].dstobj);
+				}
+			}
+		}
+		else if (!strcasecmp(objs[i].objtype, "transform"))
+		{
+			if (!transformExpressionHash)
+			{
+				info.keysize = sizeof(TransformExpressionHashKey);
+				info.entrysize = sizeof(TransformExpressionHashEntry);
+				info.hcxt = CurrentMemoryContext;
+
+				/* initialize transform expression hash common to all connector types */
+				transformExpressionHash = hash_create("transform expression hash",
+												 256,
+												 &info,
+												 HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+			}
+			memset(&expressentry, 0, sizeof(TransformExpressionHashEntry));
+
+			/*
+			 * srcobj should be expressed in fully qualified column name: db.schema.table.col or
+			 * db.table.col. dstobj is the expression to execute on the column data before applying
+			 */
+			strlcpy(expressentry.key.extObjName, objs[i].srcobj, SYNCHDB_OBJ_NAME_SIZE);
+			strlcpy(expressentry.pgsqlTransExpress, objs[i].dstobj, SYNCHDB_TRANSFORM_EXPRESSION_SIZE);
+
+			expressentrylookup = (TransformExpressionHashEntry *) hash_search(transformExpressionHash,
+					&(expressentry.key), HASH_ENTER, &found);
+
+			/* found or not, just update or insert it */
+			memset(expressentrylookup->key.extObjName, 0, SYNCHDB_OBJ_NAME_SIZE);
+			strlcpy(expressentrylookup->key.extObjName,
+					expressentry.key.extObjName,
+					SYNCHDB_OBJ_NAME_SIZE);
+
+			memset(expressentrylookup->pgsqlTransExpress, 0, SYNCHDB_TRANSFORM_EXPRESSION_SIZE);
+			strlcpy(expressentrylookup->pgsqlTransExpress,
+					expressentry.pgsqlTransExpress,
+					SYNCHDB_TRANSFORM_EXPRESSION_SIZE);
+
+			elog(WARNING, "Inserted / updated transform expression mapping '%s' <-> '%s'",
+					expressentrylookup->key.extObjName,
+					expressentrylookup->pgsqlTransExpress);
+		}
+		else if (!strcasecmp(objs[i].objtype, "datatype"))
+		{
+			char * srccopy = pstrdup(objs[i].srcobj);
+			char * dstcopy = pstrdup(objs[i].dstobj);
+			char * tmp = NULL;
+
+			memset(&hashentry, 0, sizeof(DatatypeHashEntry));
+
+			strlcpy(hashentry.key.extTypeName, strtok(srccopy, "|"), SYNCHDB_DATATYPE_NAME_SIZE);
+
+			tmp = strtok(NULL, "|");
+			if (tmp && !strcasecmp(tmp, "true"))
+				hashentry.key.autoIncremented = true;
+			else
+				hashentry.key.autoIncremented = false;
+
+			strlcpy(hashentry.pgsqlTypeName, strtok(dstcopy, "|"), SYNCHDB_DATATYPE_NAME_SIZE);
+			tmp = strtok(NULL, "|");
+			if (tmp)
+				hashentry.pgsqlTypeLength = atoi(tmp);
+			else
+				hashentry.pgsqlTypeLength = -1;
+
+			entrylookup = (DatatypeHashEntry *) hash_search(rulehash,
+					&(hashentry.key), HASH_ENTER, &found);
+
+			entrylookup->key.autoIncremented = hashentry.key.autoIncremented;
+			memset(entrylookup->key.extTypeName, 0, SYNCHDB_DATATYPE_NAME_SIZE);
+			strlcpy(entrylookup->key.extTypeName,
+					hashentry.key.extTypeName,
+					SYNCHDB_DATATYPE_NAME_SIZE);
+
+			entrylookup->pgsqlTypeLength = hashentry.pgsqlTypeLength;
+			memset(entrylookup->pgsqlTypeName, 0, SYNCHDB_DATATYPE_NAME_SIZE);
+			strlcpy(entrylookup->pgsqlTypeName,
+					hashentry.pgsqlTypeName,
+					SYNCHDB_DATATYPE_NAME_SIZE);
+
+			elog(WARNING, "Inserted / updated data type mapping '%s' <-> '%s' %d - curr %s", entrylookup->key.extTypeName,
+					entrylookup->pgsqlTypeName, entrylookup->pgsqlTypeLength, objs[i].curr_pg_atttypename);
+
+			if (objs[i].curr_pg_atttypename[0] != '\0' && objs[i].curr_pg_tbname[0] != '\0' &&
+					objs[i].curr_pg_attname[0] != '\0')
+			{
+				elog(WARNING, "comparing data types consistency for %s.%s: '%s' vs '%s'",
+						objs[i].curr_pg_tbname,
+						objs[i].curr_pg_attname,
+						objs[i].curr_pg_atttypename,
+						hashentry.pgsqlTypeName);
+				if (strcasecmp(objs[i].curr_pg_atttypename, hashentry.pgsqlTypeName))
+				{
+					/* todo complex conversion with conversion func not supported yet */
+					alter_atttype(objs[i].curr_pg_tbname, objs[i].curr_pg_attname, hashentry.pgsqlTypeName,
+							entrylookup->pgsqlTypeLength, NULL);
+				}
+			}
+		}
+	}
+	return true;
+}
+
 /*
  * fc_processDBZChangeEvent
  *
@@ -5590,6 +5878,7 @@ fc_processDBZChangeEvent(const char * event, SynchdbStatistics * myBatchStats, b
 	StringInfoData strinfo;
 	ConnectorType type;
 	MemoryContext tempContext, oldContext;
+	bool islastsnapshot = false;
 
 	tempContext = AllocSetContextCreate(TopMemoryContext,
 										"FORMAT_CONVERTER",
@@ -5621,6 +5910,8 @@ fc_processDBZChangeEvent(const char * event, SynchdbStatistics * myBatchStats, b
         	if (get_shm_connector_stage_enum(myConnectorId) != STAGE_INITIAL_SNAPSHOT)
         		set_shm_connector_stage(myConnectorId, STAGE_INITIAL_SNAPSHOT);
     	}
+    	if (!strcmp(strinfo.data, "last"))
+    		islastsnapshot = true;
     }
     else
     {
@@ -5685,7 +5976,8 @@ fc_processDBZChangeEvent(const char * event, SynchdbStatistics * myBatchStats, b
     	updateSynchdbAttribute(dbzddl, pgddl, type, name);
 
 		/* (5) clean up */
-    	set_shm_connector_state(myConnectorId, STATE_SYNCING);
+    	set_shm_connector_state(myConnectorId, (islastsnapshot && schemasync ?
+    			STATE_SCHEMA_SYNC_DONE : STATE_SYNCING));
     	elog(DEBUG1, "execution completed. Clean up...");
     	destroyDBZDDL(dbzddl);
     	destroyPGDDL(pgddl);

--- a/format_converter.h
+++ b/format_converter.h
@@ -162,7 +162,7 @@ typedef struct transformExpressionHashEntry
 } TransformExpressionHashEntry;
 
 /* Function prototypes */
-int fc_processDBZChangeEvent(const char * event, SynchdbStatistics * myBatchStats);
+int fc_processDBZChangeEvent(const char * event, SynchdbStatistics * myBatchStats, bool schemasync, const char * name);
 ConnectorType fc_get_connector_type(const char * connector);
 void fc_initFormatConverter(ConnectorType connectorType);
 void fc_deinitFormatConverter(ConnectorType connectorType);

--- a/format_converter.h
+++ b/format_converter.h
@@ -167,5 +167,7 @@ ConnectorType fc_get_connector_type(const char * connector);
 void fc_initFormatConverter(ConnectorType connectorType);
 void fc_deinitFormatConverter(ConnectorType connectorType);
 bool fc_load_rules(ConnectorType connectorType, const char * rulefile);
+bool fc_load_objmap(const char * name, ConnectorType connectorType);
+char * escapeSingleQuote(const char * in, bool addquote);
 
 #endif /* SYNCHDB_FORMAT_CONVERTER_H_ */

--- a/replication_agent.c
+++ b/replication_agent.c
@@ -924,7 +924,7 @@ ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** conne
 	strlcpy(conninfo->extra.ssl_truststore, TextDatumGetCString(res[12]), SYNCHDB_CONNINFO_KEYSTORE_SIZE);
 	strlcpy(conninfo->extra.ssl_truststore_pass, TextDatumGetCString(res[13]) ,SYNCHDB_CONNINFO_PASSWORD_SIZE);
 
-	elog(WARNING, "name %s hostname %s, port %d, user %s pwd %s srcdb %s "
+	elog(DEBUG1, "name %s hostname %s, port %d, user %s pwd %s srcdb %s "
 			"dstdb %s table %s connector %s extras(%s %s %s %s %s)",
 			conninfo->name, conninfo->hostname, conninfo->port,
 			conninfo->user, conninfo->pwd, conninfo->srcdb,

--- a/replication_agent.h
+++ b/replication_agent.h
@@ -70,5 +70,6 @@ int ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** c
 int ra_executeCommand(const char * query);
 int ra_listConnInfoNames(char ** out, int * numout);
 char * ra_transformDataExpression(char * data, char * wkb, char * srid, char * expression);
+int ra_listObjmaps(const char * name, ObjectMap ** out, int * numout);
 
 #endif /* SYNCHDB_REPLICATION_AGENT_H_ */

--- a/synchdb--1.0--1.1.sql
+++ b/synchdb--1.0--1.1.sql
@@ -1,28 +1,32 @@
 \echo Use "CREATE EXTENSION synchdb" to load this file. \quit
 
 CREATE TABLE IF NOT EXISTS synchdb_attribute (
-    connector name,
+    name name,
+    type name,
     attrelid oid,
     attnum smallint,
     ext_tbname name,
     ext_attname name,
     ext_atttypename name,
-    PRIMARY KEY (connector, attrelid, attnum)
+    transform text,
+    PRIMARY KEY (name, type, attrelid, attnum)
 );
 
 CREATE VIEW synchdb_att_view AS
 	SELECT
-		connector,
+		name,
+		type,
 		synchdb_attribute.attnum,
 		ext_tbname,
 		(SELECT n.nspname || '.' || c.relname AS table_full_name FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.oid=pg_attribute.attrelid) AS pg_tbname,
 		synchdb_attribute.ext_attname,
 		pg_attribute.attname AS pg_attname,
 		synchdb_attribute.ext_atttypename,
-		(SELECT typname FROM pg_type WHERE pg_type.oid = pg_attribute.atttypid) AS pg_atttypename
+		(SELECT typname FROM pg_type WHERE pg_type.oid = pg_attribute.atttypid) AS pg_atttypename,
+		synchdb_attribute.transform AS trasnform
 	FROM synchdb_attribute
 	LEFT JOIN pg_attribute
 	ON synchdb_attribute.attrelid = pg_attribute.attrelid
 	AND synchdb_attribute.attnum = pg_attribute.attnum
-	ORDER BY (connector, ext_tbname, synchdb_attribute.attnum);
+	ORDER BY (name, type, ext_tbname, synchdb_attribute.attnum);
 

--- a/synchdb--1.0--1.1.sql
+++ b/synchdb--1.0--1.1.sql
@@ -45,4 +45,14 @@ CREATE VIEW synchdb_att_view AS
 	AND synchdb_attribute.attnum = pg_attribute.attnum
 	ORDER BY (name, type, ext_tbname, synchdb_attribute.attnum);
 
+CREATE OR REPLACE FUNCTION synchdb_add_extra_conninfo(name, name, text, text, text, text) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION synchdb_del_extra_conninfo(name) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION synchdb_del_conninfo(name) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;

--- a/synchdb--1.0--1.1.sql
+++ b/synchdb--1.0--1.1.sql
@@ -22,6 +22,7 @@ LANGUAGE C IMMUTABLE STRICT;
 CREATE TABLE IF NOT EXISTS synchdb_objmap (
     name name,
     objtype name,
+    enabled bool,
     srcobj name,
     dstobj text,
     PRIMARY KEY (name, objtype, srcobj)
@@ -38,7 +39,7 @@ CREATE VIEW synchdb_att_view AS
 		pg_attribute.attname AS pg_attname,
 		synchdb_attribute.ext_atttypename,
 		format_type(pg_attribute.atttypid, NULL) AS pg_atttypename,
-		(SELECT dstobj FROM synchdb_objmap WHERE synchdb_objmap.objtype='transform' AND synchdb_objmap.srcobj = synchdb_attribute.ext_tbname || '.' || synchdb_attribute.ext_attname) AS transform
+		(SELECT dstobj FROM synchdb_objmap WHERE synchdb_objmap.objtype='transform' AND synchdb_objmap.enabled=true AND synchdb_objmap.srcobj = synchdb_attribute.ext_tbname || '.' || synchdb_attribute.ext_attname) AS transform
 	FROM synchdb_attribute
 	LEFT JOIN pg_attribute
 	ON synchdb_attribute.attrelid = pg_attribute.attrelid
@@ -54,5 +55,9 @@ AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
 CREATE OR REPLACE FUNCTION synchdb_del_conninfo(name) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION synchdb_del_objmap(name, name, name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;

--- a/synchdb--1.0.sql
+++ b/synchdb--1.0.sql
@@ -1,15 +1,15 @@
 --complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION synchdb" to load this file. \quit
  
-CREATE OR REPLACE FUNCTION synchdb_start_engine_bgw(text) RETURNS int
+CREATE OR REPLACE FUNCTION synchdb_start_engine_bgw(name) RETURNS int
 AS '$libdir/synchdb', 'synchdb_start_engine_bgw'
 LANGUAGE C IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION synchdb_start_engine_bgw(text, text) RETURNS int
+CREATE OR REPLACE FUNCTION synchdb_start_engine_bgw(name, name) RETURNS int
 AS '$libdir/synchdb', 'synchdb_start_engine_bgw_snapshot_mode'
 LANGUAGE C IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION synchdb_stop_engine_bgw(text) RETURNS int
+CREATE OR REPLACE FUNCTION synchdb_stop_engine_bgw(name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
@@ -19,27 +19,27 @@ LANGUAGE C IMMUTABLE STRICT;
 
 CREATE VIEW synchdb_state_view AS SELECT * FROM synchdb_get_state() AS (name text, connector_type text, pid int, stage text, state text, err text, last_dbz_offset text);
 
-CREATE OR REPLACE FUNCTION synchdb_pause_engine(text) RETURNS int
+CREATE OR REPLACE FUNCTION synchdb_pause_engine(name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION synchdb_resume_engine(text) RETURNS int
+CREATE OR REPLACE FUNCTION synchdb_resume_engine(name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION synchdb_set_offset(text, text) RETURNS int
+CREATE OR REPLACE FUNCTION synchdb_set_offset(name, text) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION synchdb_add_conninfo(text, text, int, text, text, text, text, text, text, text) RETURNS int
+CREATE OR REPLACE FUNCTION synchdb_add_conninfo(name, text, int, text, text, text, text, text, text) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION synchdb_restart_connector(text, text) RETURNS int
+CREATE OR REPLACE FUNCTION synchdb_restart_connector(name, name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION synchdb_log_jvm_meminfo(text) RETURNS int
+CREATE OR REPLACE FUNCTION synchdb_log_jvm_meminfo(name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
@@ -47,7 +47,7 @@ CREATE OR REPLACE FUNCTION synchdb_get_stats() RETURNS SETOF record
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION synchdb_reset_stats(text) RETURNS int
+CREATE OR REPLACE FUNCTION synchdb_reset_stats(name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 

--- a/synchdb.h
+++ b/synchdb.h
@@ -50,6 +50,8 @@
 #define SYNCHDB_SECRET "930e62fb8c40086c23f543357a023c0c"
 #define SYNCHDB_CONNINFO_TABLE "synchdb_conninfo"
 #define SYNCHDB_ATTRIBUTE_TABLE "synchdb_attribute"
+#define SYNCHDB_OBJECT_MAPPING_TABLE "synchdb_objmap"
+#define SYNCHDB_ATTRIBUTE_VIEW "synchdb_att_view"
 
 /* Enumerations */
 
@@ -80,7 +82,8 @@ typedef enum _connectorState
 	STATE_OFFSET_UPDATE,/* in this state when user requests offset update */
 	STATE_RESTARTING,	/* connector is restarting with new snapshot mode */
 	STATE_MEMDUMP,		/* connector is dumping jvm heap memory info */
-	STATE_SCHEMA_SYNC_DONE /* connect has completed schema sync as requested */
+	STATE_SCHEMA_SYNC_DONE, /* connect has completed schema sync as requested */
+	STATE_RELOAD_OBJMAP, /* connect is reloading object mapping */
 } ConnectorState;
 
 /**
@@ -248,6 +251,16 @@ typedef struct _SynchdbSharedState
 	LWLock		lock;		/* mutual exclusion */
 	ActiveConnectors * connectors;
 } SynchdbSharedState;
+
+typedef struct _ObjectMap
+{
+	char objtype[SYNCHDB_CONNINFO_NAME_SIZE];
+	char srcobj[SYNCHDB_CONNINFO_NAME_SIZE];
+	char dstobj[SYNCHDB_TRANSFORM_EXPRESSION_SIZE];
+	char curr_pg_tbname[SYNCHDB_CONNINFO_NAME_SIZE];
+	char curr_pg_attname[SYNCHDB_CONNINFO_NAME_SIZE];
+	char curr_pg_atttypename[SYNCHDB_CONNINFO_NAME_SIZE];
+} ObjectMap;
 
 /* Function prototypes */
 const char * get_shm_connector_name(ConnectorType type);

--- a/synchdb.h
+++ b/synchdb.h
@@ -255,6 +255,7 @@ typedef struct _SynchdbSharedState
 typedef struct _ObjectMap
 {
 	char objtype[SYNCHDB_CONNINFO_NAME_SIZE];
+	bool enabled;
 	char srcobj[SYNCHDB_CONNINFO_NAME_SIZE];
 	char dstobj[SYNCHDB_TRANSFORM_EXPRESSION_SIZE];
 	char curr_pg_tbname[SYNCHDB_CONNINFO_NAME_SIZE];

--- a/synchdb.h
+++ b/synchdb.h
@@ -80,6 +80,7 @@ typedef enum _connectorState
 	STATE_OFFSET_UPDATE,/* in this state when user requests offset update */
 	STATE_RESTARTING,	/* connector is restarting with new snapshot mode */
 	STATE_MEMDUMP,		/* connector is dumping jvm heap memory info */
+	STATE_SCHEMA_SYNC_DONE /* connect has completed schema sync as requested */
 } ConnectorState;
 
 /**
@@ -90,6 +91,7 @@ typedef enum _connectorStage
 	STAGE_UNDEF = 0,
 	STAGE_INITIAL_SNAPSHOT,
 	STAGE_CHANGE_DATA_CAPTURE,
+	STAGE_SCHEMA_SYNC,
 } ConnectorStage;
 
 /**
@@ -162,6 +164,7 @@ typedef struct _ConnectionInfo
     char table[SYNCHDB_CONNINFO_TABLELIST_SIZE];
     bool active;
     char rulefile[SYNCHDB_CONNINFO_RULEFILENAME_SIZE];
+    bool isShcemaSync;
 } ConnectionInfo;
 
 /**
@@ -256,6 +259,7 @@ void set_shm_connector_state(int connectorId, ConnectorState state);
 const char * get_shm_connector_state(int connectorId);
 void set_shm_dbz_offset(int connectorId);
 const char * get_shm_dbz_offset(int connectorId);
+const char * get_shm_connector_name_by_id(int connectorId);
 ConnectorState get_shm_connector_state_enum(int connectorId);
 const char* connectorTypeToString(ConnectorType type);
 void set_shm_connector_stage(int connectorId, ConnectorStage stage);

--- a/synchdb.h
+++ b/synchdb.h
@@ -28,6 +28,7 @@
 #define SYNCHDB_CONNINFO_TABLELIST_SIZE 256
 #define SYNCHDB_CONNINFO_RULEFILENAME_SIZE 64
 #define SYNCHDB_CONNINFO_DB_NAME_SIZE 64
+#define SYNCHDB_CONNINFO_KEYSTORE_SIZE 128
 
 #define DEBEZIUM_SHUTDOWN_TIMEOUT_MSEC 100000
 
@@ -152,6 +153,19 @@ typedef struct _BatchInfo
 } BatchInfo;
 
 /**
+ * ExtraConnectionInfo - Extra DBZ Connector parameters are put here. Should
+ * all be optional
+ */
+typedef struct _ExtraConnectionInfo
+{
+	char ssl_mode[SYNCHDB_CONNINFO_NAME_SIZE];
+	char ssl_keystore[SYNCHDB_CONNINFO_KEYSTORE_SIZE];
+	char ssl_keystore_pass[SYNCHDB_CONNINFO_PASSWORD_SIZE];
+	char ssl_truststore[SYNCHDB_CONNINFO_KEYSTORE_SIZE];
+	char ssl_truststore_pass[SYNCHDB_CONNINFO_PASSWORD_SIZE];
+} ExtraConnectionInfo;
+
+/**
  * ConnectionInfo - DBZ Connection info. These are put in shared memory so
  * connector background workers can access when they are spawned.
  */
@@ -166,8 +180,8 @@ typedef struct _ConnectionInfo
 	char dstdb[SYNCHDB_CONNINFO_DB_NAME_SIZE];
     char table[SYNCHDB_CONNINFO_TABLELIST_SIZE];
     bool active;
-    char rulefile[SYNCHDB_CONNINFO_RULEFILENAME_SIZE];
     bool isShcemaSync;
+    ExtraConnectionInfo extra;
 } ConnectionInfo;
 
 /**
@@ -178,20 +192,6 @@ typedef struct _ConnectorName
 {
 	char name[SYNCHDB_CONNINFO_NAME_SIZE];
 } ConnectorName;
-
-/**
- * ExtraConnectionInfo - Extra DBZ Connection info parameters read from the
- * rule file (if specified). These won't be put in shared memory so they
- * are declared as pointers.
- */
-typedef struct _ExtraConnectionInfo
-{
-	char * ssl_mode;
-	char * ssl_keystore;
-	char * ssl_keystore_pass;
-	char * ssl_truststore;
-	char * ssl_truststore_pass;
-} ExtraConnectionInfo;
 
 /**
  * SynchdbRequest - Structure representing a request to change connector state


### PR DESCRIPTION
summary of features added in this pr:

1) normalized all the data type mapping entries to use lower case letters
2) added a new tabled called synchdb_objmap to store differet object mapping entries
3) added a new sql function synchdb_add_objamp to add new object mapping entries, it supports table name, column name, data type and transform expressions
4) added a new sql function synchdb_reload_objmap to force a connector to reload object mapping entries
5) a connector will adjust and correct table name, column name and data type when the configured object mapping differs from current values
6) rulefile is no longer required and used. This has been replaced by synchdb_add_objmap
7) added a new snapshot mode called 'schemasync' in which the connector will obtain schemas and create the tables only before going to paused state
8) various bugfixes
9) synchdb_att_view now contains transform expressions


refer to this [issue ](https://github.com/Hornetlabs/synchdb/issues/118)for more infomation
