### PR TITLE
Fixed warnings and added github workflow CI sanity tests

### DIFF
--- a/.github/workflows/synchdb-ci.yml
+++ b/.github/workflows/synchdb-ci.yml
@@ -1,0 +1,133 @@
+name: SynchDB CI
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, synchdb-devel, github-action-test]
+  pull_request:
+    branches: [ main, synchdb-devel github-action-test]
+jobs:
+  params:
+    runs-on: ubuntu-22.04
+    name: Initialize parameters
+    outputs:
+      pg16_version: '{ "major": "16", "full": "16.8" }'
+      pg17_version: '{ "major": "17", "full": "17.4" }'
+    steps:
+      - name: set up parameters
+        run: echo 'noop'
+  build:
+    needs: params
+    name: Build for PG${{ fromJson(matrix.pg_version).major }}
+    strategy:
+      matrix:
+        pg_version:
+          - ${{ needs.params.outputs.pg16_version }}
+          - ${{ needs.params.outputs.pg17_version }}
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 22
+      uses: actions/setup-java@v2
+      with:
+        java-version: '22'
+        distribution: 'temurin'
+        architecture: x64
+        check-latest: true
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: 3.9.8
+    - name: Install pg
+      run: |
+        sudo apt-get update
+        echo -ne "\n" | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+        sudo apt-get install -y postgresql-client-${{ fromJson(matrix.pg_version).major }}
+        sudo apt-get install -y postgresql-${{ fromJson(matrix.pg_version).major }}
+        sudo apt-get install -y postgresql-server-dev-${{ fromJson(matrix.pg_version).major }}
+    - name: Expose $PG_MAJOR to Github Env
+      run: echo "PG_MAJOR=$(echo '${{ matrix.pg_version }}' | jq -r .major)" >> $GITHUB_ENV
+      shell: bash
+    - name: Build
+      run: "./ci/build-synchdb.sh"
+      shell: bash
+    - uses: actions/upload-artifact@v4
+      with:
+        name: synchdb-install-${{ env.PG_MAJOR }}
+        path: |-
+          ./synchdb-install-${{ fromJson(matrix.pg_version).major }}.tar.gz
+  test-synchdb:
+    name: PG${{ fromJson(matrix.pg_version).major }}-${{ matrix.dbtypes }} Tests
+    strategy:
+      matrix:
+        pg_version:
+          - ${{ needs.params.outputs.pg16_version }}
+          - ${{ needs.params.outputs.pg17_version }}
+        dbtypes:
+          - mysql
+          - oracle
+          - sqlserver
+    runs-on: ubuntu-22.04
+    needs:
+    - params
+    - build
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v4
+      with:
+        name: synchdb-install-${{ fromJson(matrix.pg_version).major }}
+    - name: Set up JDK 22
+      uses: actions/setup-java@v2
+      with:
+        java-version: '22'
+        distribution: 'temurin'
+        architecture: x64
+        check-latest: true
+    - name: Configure Linker
+      run: |
+        echo "configure Java"
+        JAVA_PATH=$(which java)
+        JDK_HOME_PATH=$(readlink -f ${JAVA_PATH} | sed 's:/bin/java::')
+        JDK_LIB_PATH=${JDK_HOME_PATH}/lib
+        echo $JDK_LIB_PATH | sudo tee -a /etc/ld.so.conf.d/x86_64-linux-gnu.conf
+        echo $JDK_LIB_PATH/server | sudo tee -a /etc/ld.so.conf.d/x86_64-linux-gnu.conf
+        sudo ldconfig
+    - name: Install Base PG and SynchDB
+      run: |
+        sudo apt-get update
+        echo -ne "\n" | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+        sudo apt-get install -y postgresql-client-${{ fromJson(matrix.pg_version).major }}
+        sudo apt-get install -y postgresql-${{ fromJson(matrix.pg_version).major }}
+        sudo tar xzvf synchdb-install-${{ fromJson(matrix.pg_version).major }}.tar.gz -C /
+        sudo apt-get install -y docker-compose
+        docker-compose --version
+    - name: Expose $DBTYPE to Github Env
+      run: echo "DBTYPE=${{ matrix.dbtypes }}" >> $GITHUB_ENV
+      shell: bash
+    - name: Prepare Remote Database - ${{ matrix.dbtypes }}
+      run: "./ci/setup-remotedbs.sh"
+      shell: bash
+    - name: Start PG
+      run: |
+        export PATH=$PATH:/usr/lib/postgresql/${{ fromJson(matrix.pg_version).major }}/bin
+        mkdir -p /var/run/postgresql
+        sudo chown -R $(whoami) /var/run/postgresql
+        echo "Initializing database:"
+        initdb -D synchdbtest
+        echo "Configuring PostgreSQL:"
+        echo "max_connections = 100" >> synchdbtest/postgresql.conf
+        echo "shared_buffers = 128MB" >> synchdbtest/postgresql.conf
+        echo "dynamic_shared_memory_type = posix" >> synchdbtest/postgresql.conf
+        echo "Starting PostgreSQL @ $PWD:"
+        pg_ctl -D synchdbtest -l logfile start
+        echo "PostgreSQL status:"
+        pg_ctl -D synchdbtest status 
+        docker ps
+    - name: Synchdb Sanity Tests - ${{ matrix.dbtypes }}
+      run: "./ci/test-synchdb.sh"
+      shell: bash
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: synchdb-test-outputs-${{ fromJson(matrix.pg_version).major }}-${{ matrix.dbtypes }}
+        path: |-
+          ./logfile

--- a/ci/build-synchdb.sh
+++ b/ci/build-synchdb.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+IFS=$'\n\t'
+
+# read pg major version, error if not provided
+PG_MAJOR=${PG_MAJOR:?please provide the postgres major version}
+
+# get codename from release file
+. /etc/os-release
+codename=${VERSION#*(}
+codename=${codename%)*}
+
+# we'll do everything with absolute paths
+basedir="$(pwd)"
+
+# get the project and clear out the git repo (reduce workspace size
+rm -rf "${basedir}/.git"
+
+function build_synchdb()
+{
+	pg_major="$1"
+
+	installdir="${basedir}/synchdb-install-${pg_major}"
+	mkdir -p $installdir
+	echo "Beginning build for PostgreSQL ${pg_major}..." >&2
+	#mkdir -p "${builddir}" && cd "${builddir}"
+	export USE_PGXS=1
+	make build_dbz PG_CONFIG=/usr/lib/postgresql/${pg_major}/bin/pg_config
+	make PG_CONFIG=/usr/lib/postgresql/${pg_major}/bin/pg_config
+
+	sudo USE_PGXS=1 make install DESTDIR=${installdir} PG_CONFIG=/usr/lib/postgresql/${pg_major}/bin/pg_config
+	sudo USE_PGXS=1 make install_dbz libdir=${installdir}/usr/lib/postgresql/${pg_major}/lib  PG_CONFIG=/usr/lib/postgresql/${pg_major}/bin/pg_config
+
+	cd $installdir
+	ls
+	tar czvf synchdb-install-${pg_major}.tar.gz *
+	mv synchdb-install-${pg_major}.tar.gz $basedir
+}
+
+build_synchdb "${PG_MAJOR}"

--- a/ci/setup-remotedbs.sh
+++ b/ci/setup-remotedbs.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+IFS=$'\n\t'
+
+# read pg major version, error if not provided
+DBTYPE=${DBTYPE:?please provide database type}
+
+# get codename from release file
+. /etc/os-release
+codename=${VERSION#*(}
+codename=${codename%)*}
+
+# we'll do everything with absolute paths
+basedir="$(pwd)"
+
+# get the project and clear out the git repo (reduce workspace size
+rm -rf "${basedir}/.git"
+
+
+function setup_mysql()
+{
+	echo "setting up mysql..."
+	docker-compose -f testenv/mysql/synchdb-mysql-test.yaml up -d
+	echo "sleep to give container time to startup..."
+	sleep 20  # Give containers time to fully start
+	docker exec -i mysql mysql -uroot -pmysqlpwdroot -e "SELECT VERSION();" || { echo "Failed to connect to MySQL"; docker logs mysql; exit 1; }
+	docker exec -i mysql mysql -uroot -pmysqlpwdroot << EOF
+GRANT replication client ON *.* TO mysqluser;
+GRANT replication slave ON *.* TO mysqluser;
+GRANT RELOAD ON *.* TO 'mysqluser'@'%';
+FLUSH PRIVILEGES;
+EOF
+	exit 0
+}
+
+function setup_sqlserver()
+{
+
+	echo "setting up sqlserv...er"
+	docker-compose -f testenv/sqlserver/synchdb-sqlserver-test.yaml up -d
+	echo "sleep to give container time to startup..."
+	sleep 20  # Give containers time to fully start
+	id=$(docker ps | grep sqlserver | awk '{print $1}')
+	docker cp inventory.sql $id:/
+	docker exec -i $id /opt/mssql-tools18/bin/sqlcmd -U sa -P 'Password!' -C -Q "SELECT @@VERSION" > /dev/null
+	docker exec -i $id /opt/mssql-tools18/bin/sqlcmd -U sa -P 'Password!' -C -i /inventory.sql > /dev/null
+	exit 0
+}
+
+function setup_oracle()
+{
+	echo "setting up oracle..."
+	docker run -d -p 1521:1521 container-registry.oracle.com/database/free:latest
+	echo "sleep to give container time to startup..."
+    sleep 20  # Give containers time to fully start
+	id=$(docker ps | grep oracle | awk '{print $1}')
+	docker exec -i $id mkdir /opt/oracle/oradata/recovery_area
+	docker exec -i $id sqlplus / as sysdba <<EOF
+Alter user sys identified by oracle;
+exit;
+EOF
+	docker exec -i $id sqlplus /nolog <<EOF
+CONNECT sys/oracle as sysdba;
+alter system set db_recovery_file_dest_size = 10G;
+alter system set db_recovery_file_dest = '/opt/oracle/oradata/recovery_area' scope=spfile;
+shutdown immediate;
+startup mount;
+alter database archivelog;
+alter database open;
+archive log list;
+exit;
+EOF
+	docker exec -i $id sqlplus sys/oracle@//localhost:1521/FREE as sysdba <<EOF
+ALTER DATABASE ADD SUPPLEMENTAL LOG DATA;
+ALTER PROFILE DEFAULT LIMIT FAILED_LOGIN_ATTEMPTS UNLIMITED;
+exit;
+EOF
+	docker exec -i $id sqlplus sys/oracle@//localhost:1521/FREE as sysdba <<EOF
+CREATE TABLESPACE LOGMINER_TBS DATAFILE '/opt/oracle/oradata/FREE/logminer_tbs.dbf' SIZE 25M REUSE AUTOEXTEND ON MAXSIZE UNLIMITED;
+exit;
+EOF
+	docker exec -i $id sqlplus sys/oracle@//localhost:1521/FREEPDB1 as sysdba <<EOF
+CREATE TABLESPACE LOGMINER_TBS DATAFILE '/opt/oracle/oradata/FREE/FREEPDB1/logminer_tbs.dbf' SIZE 25M REUSE AUTOEXTEND ON MAXSIZE UNLIMITED;
+exit;
+EOF
+	docker exec -i $id sqlplus sys/oracle@//localhost:1521/FREE as sysdba <<'EOF'
+CREATE USER c##dbzuser IDENTIFIED BY dbz DEFAULT TABLESPACE LOGMINER_TBS QUOTA UNLIMITED ON LOGMINER_TBS CONTAINER=ALL;
+GRANT CREATE SESSION TO c##dbzuser CONTAINER=ALL;
+GRANT SET CONTAINER TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$DATABASE TO c##dbzuser CONTAINER=ALL;
+GRANT FLASHBACK ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT_CATALOG_ROLE TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE_CATALOG_ROLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY TRANSACTION TO c##dbzuser CONTAINER=ALL;
+GRANT LOGMINING TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY DICTIONARY TO c##dbzuser CONTAINER=ALL;
+GRANT CREATE TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT LOCK ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT CREATE SEQUENCE TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE ON DBMS_LOGMNR TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE ON DBMS_LOGMNR_D TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOG TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOG_HISTORY TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_LOGS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_CONTENTS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_PARAMETERS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGFILE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$ARCHIVED_LOG TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$ARCHIVE_DEST_STATUS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$TRANSACTION TO c##dbzuser CONTAINER=ALL; 
+GRANT SELECT ON V_$MYSTAT TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$STATNAME TO c##dbzuser CONTAINER=ALL; 
+GRANT EXECUTE ON DBMS_WORKLOAD_REPOSITORY TO C##DBZUSER;
+GRANT SELECT ON DBA_HIST_SNAPSHOT TO C##DBZUSER;
+GRANT EXECUTE ON DBMS_WORKLOAD_REPOSITORY TO PUBLIC;
+ALTER DATABASE ADD LOGFILE GROUP 4 ('/opt/oracle/oradata/FREE/redo04.log') SIZE 1G;
+ALTER DATABASE ADD LOGFILE GROUP 5 ('/opt/oracle/oradata/FREE/redo05.log') SIZE 1G;
+ALTER DATABASE ADD LOGFILE GROUP 6 ('/opt/oracle/oradata/FREE/redo06.log') SIZE 1G;
+exit;
+EOF
+
+	docker exec -i $id sqlplus 'c##dbzuser/dbz@//localhost:1521/FREE' <<EOF
+CREATE TABLE orders (
+id NUMBER PRIMARY KEY,
+order_date DATE,
+purchaser NUMBER,
+quantity NUMBER,
+product_id NUMBER);
+commit;
+ALTER TABLE orders ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
+exit;
+EOF
+
+	docker exec -i $id sqlplus 'c##dbzuser/dbz@//localhost:1521/FREE' <<EOF
+INSERT INTO orders(id, order_date, purchaser, quantity, product_id) VALUES (1, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
+INSERT INTO orders(id, order_date, purchaser, quantity, product_id) VALUES (2, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
+INSERT INTO orders(id, order_date, purchaser, quantity, product_id) VALUES (3, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
+INSERT INTO orders(id, order_date, purchaser, quantity, product_id) VALUES (4, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
+commit;
+exit;
+EOF
+	exit 0
+}
+
+function setup_remotedb()
+{
+	dbtype="$1"
+
+	case "$dbtype" in
+		"mysql")
+			setup_mysql
+			;;
+		"sqlserver")
+			setup_sqlserver
+			;;
+		"oracle")
+			setup_oracle
+			;;
+		*)
+			echo "$dbtype not supported"
+			exit 1
+			;;
+	esac
+}
+
+setup_remotedb "${DBTYPE}"

--- a/ci/test-synchdb.sh
+++ b/ci/test-synchdb.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+IFS=$'\n\t'
+
+# read pg major version, error if not provided
+DBTYPE=${DBTYPE:?please provide database type}
+
+# get codename from release file
+. /etc/os-release
+codename=${VERSION#*(}
+codename=${codename%)*}
+
+# we'll do everything with absolute paths
+basedir="$(pwd)"
+
+# get the project and clear out the git repo (reduce workspace size
+rm -rf "${basedir}/.git"
+
+
+function test_mysql()
+{
+	echo "testing mysql..."
+	psql -d postgres -c "SELECT synchdb_add_conninfo('mysqlconn', '127.0.0.1', 3306, 'mysqluser', 'mysqlpwd', 'inventory', 'postgres', '', 'mysql');"
+	if [ $? -ne 0 ]; then
+		echo "failed to create connector"
+		exit 1
+	fi
+
+	psql -d postgres -c "SELECT synchdb_start_engine_bgw('mysqlconn');"
+	if [ $? -ne 0 ]; then
+		echo "failed to start connector"
+		exit 1
+	fi
+	echo "waiting for initial snapshot before checking results..."
+	sleep 10
+	psql -d postgres -c "SELECT * FROM synchdb_state_view;"
+	syncing_src_count=$(docker exec -i mysql mysql -umysqluser -pmysqlpwd -sN -e "SELECT COUNT(*) from inventory.orders" | tr -d ' \r\n')
+	syncing_dst_count=$(psql -d postgres -t -c "SELECT COUNT(*) from inventory.orders;" | tr -d ' \n')
+	if [ "$syncing_src_count" -ne "$syncing_dst_count" ]; then
+		echo "initial snapshot failed. orders table count mismatch: src:$syncing_src_count vs dst:$syncing_dst_count"
+		exit 1
+	fi
+	echo "initial snapshot test done, orders table count matched: src:$syncing_src_count vs dst:$syncing_dst_count"
+
+	docker exec -i mysql mysql -umysqluser -pmysqlpwd -e "INSERT INTO inventory.orders(order_date, purchaser, quantity, product_id) VALUES ('2024-01-01', 1003, 2, 107)"
+	echo "waiting for CDC before checking results..."
+	sleep 10
+	syncing_src_count=$(docker exec -i mysql mysql -umysqluser -pmysqlpwd -sN -e "SELECT COUNT(*) from inventory.orders" | tr -d ' \r\n')
+	syncing_dst_count=$(psql -d postgres -t -c "SELECT COUNT(*) from inventory.orders;" | tr -d ' \n')
+	if [ "$syncing_src_count" -ne "$syncing_dst_count" ]; then
+		echo "CDC failed. orders table count mismatch: src:$syncing_src_count vs dst:$syncing_dst_count"
+		exit 1
+	fi
+	echo "CDC test done, orders table count matched: src:$syncing_src_count vs dst:$syncing_dst_count"
+	psql -d postgres -c "SELECT * FROM synchdb_stats_view;"
+	exit 0
+}
+
+function test_sqlserver()
+{
+
+	echo "testing sqlserver..."
+	id=$(docker ps | grep sqlserver | awk '{print $1}')
+	psql -d postgres -c "SELECT synchdb_add_conninfo('sqlserverconn', '127.0.0.1', 1433, 'sa', 'Password!', 'testDB', 'postgres', '', 'sqlserver');"
+	if [ $? -ne 0 ]; then
+		echo "failed to create connector"
+		exit 1
+	fi
+	
+	psql -d postgres -c "SELECT synchdb_start_engine_bgw('sqlserverconn');"
+	if [ $? -ne 0 ]; then
+		echo "failed to start connector"
+		exit 1
+	fi
+	
+	echo "waiting for initial snapshot before checking results..."
+	sleep 10
+	psql -d postgres -c "SELECT * FROM synchdb_state_view;"
+	syncing_src_count=$(docker exec -i $id /opt/mssql-tools18/bin/sqlcmd -U sa -P 'Password!' -d testDB -C -Q "SELECT COUNT(*) from orders" -h -1 | sed -n '1p' | tr -d ' \r\n')
+	syncing_dst_count=$(psql -d postgres -t -c "SELECT COUNT(*) from testDB.orders;" | tr -d ' \n')
+	if [ "$syncing_src_count" -ne "$syncing_dst_count" ]; then
+		echo "initial snapshot failed. orders table count mismatch: src:$syncing_src_count vs dst:$syncing_dst_count"
+		exit 1
+	fi
+	echo "initial snapshot test done, orders table count matched: src:$syncing_src_count vs dst:$syncing_dst_count"
+
+	docker exec -i $id /opt/mssql-tools18/bin/sqlcmd -U sa -P 'Password!' -d testDB -C -Q "INSERT INTO orders(order_date, purchaser, quantity, product_id) VALUES ('2024-01-01', 1003, 2, 107)"
+	echo "waiting for CDC before checking results..."
+	sleep 10
+	syncing_src_count=$(docker exec -i $id /opt/mssql-tools18/bin/sqlcmd -U sa -P 'Password!' -d testDB -C -Q "SELECT COUNT(*) from orders" -h -1 | sed -n '1p' | tr -d ' \r\n')
+	syncing_dst_count=$(psql -d postgres -t -c "SELECT COUNT(*) from testDB.orders;" | tr -d ' \n')
+
+	if [ "$syncing_src_count" -ne "$syncing_dst_count" ]; then
+		echo "CDC failed. orders table count mismatch: src:$syncing_src_count vs dst:$syncing_dst_count"
+		exit 1
+	fi
+	echo "CDC test done, orders table count matched: src:$syncing_src_count vs dst:$syncing_dst_count"
+	psql -d postgres -c "SELECT * FROM synchdb_stats_view;"
+	exit 0
+}
+
+function test_oracle()
+{
+	echo "testing oracle..."
+	id=$(docker ps | grep oracle | awk '{print $1}')
+	psql -d postgres -c "SELECT synchdb_add_conninfo('oracleconn','127.0.0.1', 1521, 'c##dbzuser', 'dbz', 'FREE', 'postgres', '', 'oracle');"
+	if [ $? -ne 0 ]; then
+		echo "failed to create connector"
+		exit 1
+	fi
+
+	psql -d postgres -c "SELECT synchdb_start_engine_bgw('oracleconn');"
+	if [ $? -ne 0 ]; then
+		echo "failed to start connector"
+		exit 1
+	fi
+
+	echo "waiting for initial snapshot before checking results..."
+	sleep 20
+	psql -d postgres -c "SELECT * FROM synchdb_state_view;"
+	syncing_src_count=$(docker exec -i $id sqlplus -S 'c##dbzuser/dbz@//localhost:1521/FREE' <<EOF | awk '{print $1}'
+SET HEADING OFF;
+SET FEEDBACK OFF;
+SET PAGESIZE 0;
+SELECT count(*) FROM orders;
+exit
+EOF
+)
+	syncing_dst_count=$(psql -d postgres -t -c "SELECT COUNT(*) from free.orders;" | tr -d ' \n')
+	if [ "$syncing_src_count" -ne "$syncing_dst_count" ]; then
+		echo "initial snapshot failed. orders table count mismatch: src:$syncing_src_count vs dst:$syncing_dst_count"
+		exit 1
+	fi
+	echo "initial snapshot test done, orders table count matched: src:$syncing_src_count vs dst:$syncing_dst_count"
+
+	docker exec -i $id sqlplus 'c##dbzuser/dbz@//localhost:1521/FREE' <<EOF
+INSERT INTO orders(id, order_date, purchaser, quantity, product_id) VALUES (5, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
+commit;
+exit;
+EOF
+	echo "waiting for CDC before checking results..."
+	sleep 40
+	syncing_src_count=$(docker exec -i $id sqlplus -S 'c##dbzuser/dbz@//localhost:1521/FREE' <<EOF | awk '{print $1}'
+SET HEADING OFF;
+SET FEEDBACK OFF;
+SET PAGESIZE 0;
+SELECT count(*) FROM orders;
+exit
+EOF
+)
+    syncing_dst_count=$(psql -d postgres -t -c "SELECT COUNT(*) from free.orders;" | tr -d ' \n')
+	if [ "$syncing_src_count" -ne "$syncing_dst_count" ]; then
+		echo "CDC failed. orders table count mismatch: src:$syncing_src_count vs dst:$syncing_dst_count"
+		exit 1
+	fi
+	psql -d postgres -c "SELECT * FROM synchdb_stats_view;"
+	echo "CDC test done, orders table count matched: src:$syncing_src_count vs dst:$syncing_dst_count"
+	exit 0
+}
+
+function test_synchdb()
+{
+	dbtype="$1"
+
+	case "$dbtype" in
+		"mysql")
+			test_mysql
+			;;
+		"sqlserver")
+			test_sqlserver
+			;;
+		"oracle")
+			test_oracle
+			;;
+		*)
+			echo "$dbtype not supported"
+			exit 1
+			;;
+	esac
+}
+
+# CREATE synchdb
+echo "CREATE synchdb extension..."
+
+psql -d postgres -c "CREATE EXTENSION synchdb CASCADE;"
+if [ $? -ne 0 ]; then
+	echo "failed to create synchdb extension"
+	exit 1
+fi
+
+test_synchdb "${DBTYPE}"

--- a/format_converter.c
+++ b/format_converter.c
@@ -862,7 +862,6 @@ build_schema_jsonpos_hash(Jsonb * jb)
 							&hash_ctl,
 							HASH_ELEM | HASH_CONTEXT);
 
-//	schemadata = getPathElementJsonb(jb, "schema.fields.0.fields");
 	schemadata = DatumGetJsonbP(jsonb_get_element(jb, &datum_elems[0], 4, &isnull, false));
 	if (schemadata)
 	{
@@ -1129,7 +1128,6 @@ parseDBZDDL(Jsonb * jb, bool isfirst, bool islast)
     			CStringGetTextDatum("0"), CStringGetTextDatum("table"), CStringGetTextDatum("columns")};
     	bool isnull;
 
-//		ddlpayload = getPathElementJsonb(jb, "payload.tableChanges.0.table.columns");
     	ddlpayload = DatumGetJsonbP(jsonb_get_element(jb, &datum_elems[0], 5, &isnull, false));
 		/*
 		 * following parser expects this json array named 'columns' from DBZ embedded:
@@ -2665,8 +2663,7 @@ processDataByType(DBZ_DML_COLUMN_VALUE * colval, bool addquote, char * remoteObj
 			else
 			{
 				/* no extra processing for nunmeric types in other connectors */
-				out = (char *) palloc0(strlen(in) + 1);
-				strlcpy(out, in, strlen(in) + 1);
+				out = pstrdup(in);
 			}
 			break;
 		}
@@ -2785,8 +2782,7 @@ processDataByType(DBZ_DML_COLUMN_VALUE * colval, bool addquote, char * remoteObj
 			}
 			else
 			{
-				out = (char *) palloc0(strlen(in) + 1);
-				strlcpy(out, in, strlen(in) + 1);
+				out = pstrdup(in);
 			}
 			break;
 		}
@@ -2890,7 +2886,7 @@ processDataByType(DBZ_DML_COLUMN_VALUE * colval, bool addquote, char * remoteObj
 			else
 			{
 				out = (char *) palloc0(strlen(datestr) + 1);
-				strlcpy(out, datestr,strlen(datestr) + 1);
+				strcpy(out, datestr);
 			}
 			break;
 		}
@@ -2933,8 +2929,7 @@ processDataByType(DBZ_DML_COLUMN_VALUE * colval, bool addquote, char * remoteObj
 					}
 					else
 					{
-						out = (char *) palloc0(strlen(in) + 1);
-						strlcpy(out, in, strlen(in) + 1);
+						out = pstrdup(in);
 					}
 
 					/* skip the rest of processing */
@@ -2984,7 +2979,7 @@ processDataByType(DBZ_DML_COLUMN_VALUE * colval, bool addquote, char * remoteObj
 			else
 			{
 				out = (char *) palloc0(strlen(timestamp) + 1);
-				strlcpy(out, timestamp, strlen(timestamp) + 1);
+				strcpy(out, timestamp);
 			}
 			break;
 		}
@@ -3047,7 +3042,7 @@ processDataByType(DBZ_DML_COLUMN_VALUE * colval, bool addquote, char * remoteObj
 			else
 			{
 				out = (char *) palloc0(strlen(time) + 1);
-				strlcpy(out, time, strlen(time) + 1);
+				strcpy(out, time);
 			}
 			break;
 		}
@@ -3213,8 +3208,7 @@ processDataByType(DBZ_DML_COLUMN_VALUE * colval, bool addquote, char * remoteObj
 			}
 			else
 			{
-				out = (char *) palloc0(strlen(in) + 1);
-				strlcpy(out, in, strlen(in) + 1);
+				out = pstrdup(in);
 			}
 			break;
 		}
@@ -4066,7 +4060,6 @@ parseDBZDML(Jsonb * jb, char op, ConnectorType type, Jsonb * source, bool isfirs
 			 */
 			Datum datum_elems[2] ={CStringGetTextDatum("payload"), CStringGetTextDatum("after")};
 			dmlpayload = DatumGetJsonbP(jsonb_get_element(jb, &datum_elems[0], 2, &isnull, false));
-//			dmlpayload = getPathElementJsonb(jb, "payload.after");
 			if (dmlpayload)
 			{
 				int pause = 0;
@@ -4212,7 +4205,6 @@ parseDBZDML(Jsonb * jb, char op, ConnectorType type, Jsonb * source, bool isfirs
 			 * 		"after": null
 			 * 	}
 			 */
-//			dmlpayload = getPathElementJsonb(jb, "payload.before");
 			Datum datum_elems[2] = { CStringGetTextDatum("payload"), CStringGetTextDatum("before")};
 			dmlpayload = DatumGetJsonbP(jsonb_get_element(jb, &datum_elems[0], 2, &isnull, false));
 			if (dmlpayload)
@@ -4372,13 +4364,11 @@ parseDBZDML(Jsonb * jb, char op, ConnectorType type, Jsonb * source, bool isfirs
 				/* need to parse before and after */
 				if (i == 0)
 				{
-//					dmlpayload = getPathElementJsonb(jb, "payload.before");
 					Datum datum_elems[2] = { CStringGetTextDatum("payload"), CStringGetTextDatum("before")};
 					dmlpayload = DatumGetJsonbP(jsonb_get_element(jb, &datum_elems[0], 2, &isnull, false));
 				}
 				else
 				{
-//					dmlpayload = getPathElementJsonb(jb, "payload.after");
 					Datum datum_elems[2] = { CStringGetTextDatum("payload"), CStringGetTextDatum("after")};
 					dmlpayload = DatumGetJsonbP(jsonb_get_element(jb, &datum_elems[0], 2, &isnull, false));
 				}
@@ -5162,7 +5152,7 @@ fc_load_rules(ConnectorType connectorType, const char * rulefile)
 
 	/* Allocate memory to store file contents */
 	json_string = palloc0(jsonlength + 1);
-	fread(json_string, 1, jsonlength, file);
+	(void) fread(json_string, 1, jsonlength, file);
 	json_string[jsonlength] = '\0';
 
 	fclose(file);

--- a/replication_agent.c
+++ b/replication_agent.c
@@ -303,12 +303,12 @@ spi_execute(const char * query, ConnectorType type)
 static int
 synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type)
 {
-	Relation rel;
+	Relation rel = NULL;
 	TupleTableSlot *slot;
-	EState	   *estate;
+	EState	   *estate = NULL;
 	RangeTblEntry *rte;
 	List	   *perminfos = NIL;
-	ResultRelInfo *resultRelInfo;
+	ResultRelInfo *resultRelInfo = NULL;
 	ListCell * cell;
 
 	/*
@@ -432,12 +432,12 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type)
 static int
 synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, ConnectorType type)
 {
-	Relation rel;
+	Relation rel = NULL;
 	TupleTableSlot * remoteslot, * localslot;
-	EState	   *estate;
+	EState	   *estate = NULL;
 	RangeTblEntry *rte;
 	List	   *perminfos = NIL;
-	ResultRelInfo *resultRelInfo;
+	ResultRelInfo *resultRelInfo = NULL;
 	ListCell * cell;
 	int ret = 0;
 	EPQState	epqstate;
@@ -615,12 +615,12 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 static int
 synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type)
 {
-	Relation rel;
+	Relation rel = NULL;
 	TupleTableSlot * remoteslot, * localslot;
-	EState	   *estate;
+	EState	   *estate = NULL;
 	RangeTblEntry *rte;
 	List	   *perminfos = NIL;
-	ResultRelInfo *resultRelInfo;
+	ResultRelInfo *resultRelInfo = NULL;
 	ListCell * cell;
 	int ret = 0;
 	EPQState	epqstate;

--- a/synchdb.c
+++ b/synchdb.c
@@ -2897,7 +2897,7 @@ synchdb_start_engine_bgw_snapshot_mode(PG_FUNCTION_ARGS)
 	BackgroundWorkerHandle *handle;
 	BgwHandleStatus status;
 	pid_t pid;
-	ConnectionInfo connInfo;
+	ConnectionInfo connInfo = {0};
 	char *connector = NULL;
 	int ret = -1, connectorid = -1;
 	StringInfoData strinfo;
@@ -2993,7 +2993,7 @@ synchdb_start_engine_bgw(PG_FUNCTION_ARGS)
 	BackgroundWorkerHandle *handle;
 	BgwHandleStatus status;
 	pid_t pid;
-	ConnectionInfo connInfo;
+	ConnectionInfo connInfo = {0};
 	char *connector = NULL;
 	int ret = -1, connectorid = -1;
 	StringInfoData strinfo;

--- a/synchdb.c
+++ b/synchdb.c
@@ -1555,9 +1555,9 @@ processRequestInterrupt(const ConnectionInfo *connInfo, ConnectorType type, int 
 		elog(LOG, "resuimg dbz engine with host %s, port %u, user %s, src_db %s, "
 				"dst_db %s, table %s, snapshotMode %s",
 				newConnInfo.hostname, newConnInfo.port, newConnInfo.user,
-				newConnInfo.srcdb ? newConnInfo.srcdb : "N/A",
+				strlen(newConnInfo.srcdb) > 0 ? newConnInfo.srcdb : "N/A",
 				newConnInfo.dstdb,
-				newConnInfo.table ? newConnInfo.table : "N/A",
+				strlen(newConnInfo.table) ? newConnInfo.table : "N/A",
 				reqcopy->reqdata);
 
 		elog(WARNING, "resuimg dbz engine with snapshot_mode %s...", reqcopy->reqdata);
@@ -1656,9 +1656,9 @@ setup_environment(ConnectorType * connectorType, ConnectionInfo *conninfo, char 
 			" snapshotMode %s",
 			myConnectorId, conninfo->name,
 			conninfo->hostname, conninfo->port, conninfo->user,
-			conninfo->srcdb ? conninfo->srcdb : "N/A",
+			strlen(conninfo->srcdb) > 0 ? conninfo->srcdb : "N/A",
 			conninfo->dstdb,
-			conninfo->table ? conninfo->table : "N/A",
+			strlen(conninfo->table) > 0 ? conninfo->table : "N/A",
 			*connectorType, connectorTypeToString(*connectorType),
 			conninfo->name, *snapshotMode);
 
@@ -2254,7 +2254,7 @@ get_shm_connector_stage(int connectorId)
 	ConnectorStage stage;
 
 	if (!sdb_state)
-		return STATE_UNDEF;
+		return "unknown";
 
 	/*
 	 * We're only reading, so shared lock is sufficient.
@@ -2402,7 +2402,7 @@ get_shm_connector_stage_enum(int connectorId)
 	ConnectorStage stage;
 
 	if (!sdb_state)
-		return STATE_UNDEF;
+		return STAGE_UNDEF;
 
 	/*
 	 * We're only reading, so shared lock is sufficient.


### PR DESCRIPTION
1) fixed warnings reported by different gcc versions in various build platforms
2) added github workflow to automatically build and test synchdb in all supported postgresql major versions and run sanity tests using supported heterogeneous databases (mysql, oracle and sqlserver). This is only a sanity test that tests only the core functionalities of synchdb. A full regression test cases will need to be designed and implemented in near future