### PR TITLE
fixed a potential crash when using cached tupdesc where natts is not saved by mistake

### DIFF
--- a/format_converter.c
+++ b/format_converter.c
@@ -4338,6 +4338,7 @@ parseDBZDML(Jsonb * jb, char op, ConnectorType type, Jsonb * source, bool isfirs
 		typeidhash = cacheentry->typeidhash;
 		dbzdml->tableoid = cacheentry->tableoid;
 		namejsonposhash = cacheentry->namejsonposhash;
+		dbzdml->natts = cacheentry->natts;
 	}
 	else
 	{
@@ -4396,6 +4397,7 @@ parseDBZDML(Jsonb * jb, char op, ConnectorType type, Jsonb * source, bool isfirs
 		/* cache tupdesc and save natts for later use */
 		cacheentry->tupdesc = CreateTupleDescCopy(tupdesc);
 		dbzdml->natts = tupdesc->natts;
+		cacheentry->natts = dbzdml->natts;
 
 		for (attnum = 1; attnum <= tupdesc->natts; attnum++)
 		{

--- a/format_converter.h
+++ b/format_converter.h
@@ -158,6 +158,7 @@ typedef struct dataCacheEntry
 	Oid tableoid;
 	HTAB * typeidhash;
 	HTAB * namejsonposhash;
+	int natts;
 } DataCacheEntry;
 
 typedef struct datatypeHashKey


### PR DESCRIPTION
crash happens when data cache is used to process a oracle change event with less than created column numbers. The natts is not used and cached. This pullrequest fixes this to avoid the crash during apply