### PR TITLE
enhance performance by reducing JNI calls

### DIFF
--- a/ci/teardown-remotedbs.sh
+++ b/ci/teardown-remotedbs.sh
@@ -34,10 +34,14 @@ function teardown_oracle()
 {
 	echo "tearing down oracle..."
 	docker-compose -f testenv/oracle/synchdb-oracle-test.yaml down
-	#id=$(docker ps | grep oracle | awk '{print $1}')
-	#docker stop $id
-	#docker remove $id
 	exit 0
+}
+
+function teardown_ora19c()
+{
+	echo "tearing down ora19c..."
+	docker stop ora19c
+	docker rm ora19c
 }
 
 function teardown_hammerdb()
@@ -61,6 +65,9 @@ function teardown_remotedb()
 			;;
 		"oracle")
 			teardown_oracle
+			;;
+		"ora19c")
+			teardown_ora19c
 			;;
 		"hammerdb")
 			teardown_hammerdb

--- a/testenv/oracle/synchdb-oracle-test.yaml
+++ b/testenv/oracle/synchdb-oracle-test.yaml
@@ -1,6 +1,6 @@
 services:
   oracle:
     container_name: oracle
-    image: container-registry.oracle.com/database/free:latest
+    image: hgneon/testdb-oracle:23ai
     ports:
       - 1521:1521


### PR DESCRIPTION
1) enhanced the performance by reducing JNI calls during during getChangeEvents(). This is achieved by replacing the List<String> it used to return with one serialized direct buffer that the C side can process directly instead of calling JNI to access the List resource and iterate over the list via JNI. Observed a 5% increase in benchmark

2) enhanced the test suite by using docker images hosted in hgneon dockerhub rather than their original source to ensure consistency of test results across different machines. Also add an option to setup oracle 19c though the test currently does not use it because it takes too long to set up. Still keep it in there in case we would like to set up one for manual testing