### PR TITLE
Issue-153: resolve the seg fault due to invalid memory context used in spi_execute_select_one()

### DIFF
--- a/replication_agent.c
+++ b/replication_agent.c
@@ -125,6 +125,7 @@ spi_execute_select_one(const char * query, int * numcols)
 	Datum * rowval;
 	bool isnull;
 	bool skiptx = false;
+	MemoryContext oldcontext;
 
 	/*
 	 * if we are already in transaction or transaction block, we can skip
@@ -190,6 +191,7 @@ spi_execute_select_one(const char * query, int * numcols)
 	tupdesc = SPI_tuptable->tupdesc;
 	*numcols = tupdesc->natts;
 
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
 	rowval = (Datum *) palloc0(*numcols * sizeof(Datum));
 
 	for (i = 0; i < *numcols; i++)
@@ -200,6 +202,7 @@ spi_execute_select_one(const char * query, int * numcols)
 		else
 			rowval[i] = colval;
 	}
+	MemoryContextSwitchTo(oldcontext);
 
 	/* Close the connection */
 	SPI_finish();


### PR DESCRIPTION
resolved a problem where spi_execute_select_one() returns value pointers that have been destroyed by SPI memory context. Solution is to make allocation to top memory context before the function allocate return value pointers.

this should resolve the issue reported here: https://github.com/Hornetlabs/synchdb/issues/153