### PR TITLE
support for jmx and jmx exporter + bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,9 @@ clean_dbz:
 	cd $(DBZ_ENGINE_PATH) && mvn clean
 
 install_dbz:
-	rm -rf $(libdir)/dbz_engine
-	install -d $(libdir)/dbz_engine
-	cp -rp $(DBZ_ENGINE_PATH)/target/* $(libdir)/dbz_engine
+	rm -rf $(pkglibdir)/dbz_engine
+	install -d $(pkglibdir)/dbz_engine
+	cp -rp $(DBZ_ENGINE_PATH)/target/* $(pkglibdir)/dbz_engine
 
 .PHONY: dbcheck mysqlcheck sqlservercheck oraclecheck dbcheck-tpcc mysqlcheck-tpcc sqlservercheck-tpcc oraclecheck-tpcc
 dbcheck:

--- a/ci/build-synchdb.sh
+++ b/ci/build-synchdb.sh
@@ -28,7 +28,7 @@ function build_synchdb()
 	make PG_CONFIG=/usr/lib/postgresql/${pg_major}/bin/pg_config
 
 	sudo USE_PGXS=1 make install DESTDIR=${installdir} PG_CONFIG=/usr/lib/postgresql/${pg_major}/bin/pg_config
-	sudo USE_PGXS=1 make install_dbz libdir=${installdir}/usr/lib/postgresql/${pg_major}/lib  PG_CONFIG=/usr/lib/postgresql/${pg_major}/bin/pg_config
+	sudo USE_PGXS=1 make install_dbz pkglibdir=${installdir}/usr/lib/postgresql/${pg_major}/lib  PG_CONFIG=/usr/lib/postgresql/${pg_major}/bin/pg_config
 
 	cd $installdir
 	ls

--- a/replication_agent.c
+++ b/replication_agent.c
@@ -902,10 +902,25 @@ ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** conne
 			"coalesce(data->>'ssl_keystore', 'null'), "
 			"coalesce(pgp_sym_decrypt((data->>'ssl_keystore_pass')::bytea, '%s'), 'null'), "
 			"coalesce(data->>'ssl_truststore', 'null'), "
-			"coalesce(pgp_sym_decrypt((data->>'ssl_truststore_pass')::bytea, '%s'), 'null') "
+			"coalesce(pgp_sym_decrypt((data->>'ssl_truststore_pass')::bytea, '%s'), 'null'), "
+			"coalesce(data->>'jmx_listenaddr', 'null'), "
+			"coalesce(data->>'jmx_port', 'null'), "
+			"coalesce(data->>'jmx_rmi_address', 'null'), "
+			"coalesce(data->>'jmx_rmi_port', 'null'), "
+			"(data->>'jmx_auth')::boolean, "
+			"coalesce(data->>'jmx_auth_passwdfile', 'null'), "
+			"coalesce(data->>'jmx_auth_accessfile', 'null'), "
+			"(data->>'jmx_ssl')::boolean, "
+			"coalesce(data->>'jmx_ssl_keystore', 'null'), "
+			"coalesce(pgp_sym_decrypt((data->>'jmx_ssl_keystore_pass')::bytea, '%s'), 'null'), "
+			"coalesce(data->>'jmx_ssl_truststore', 'null'), "
+			"coalesce(pgp_sym_decrypt((data->>'jmx_ssl_truststore_pass')::bytea, '%s'), 'null'), "
+			"coalesce(data->>'jmx_exporter', 'null'), "
+			"coalesce(data->>'jmx_exporter_port', 'null'), "
+			"coalesce(data->>'jmx_exporter_conf', 'null') "
 			"FROM "
 			"synchdb_conninfo WHERE name = '%s'",
-			SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, name);
+			SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, name);
 
 	res = spi_execute_select_one(strinfo.data, &numcols);
 	if (!res)
@@ -928,13 +943,42 @@ ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** conne
 	strlcpy(conninfo->extra.ssl_truststore, TextDatumGetCString(res[13]), SYNCHDB_CONNINFO_KEYSTORE_SIZE);
 	strlcpy(conninfo->extra.ssl_truststore_pass, TextDatumGetCString(res[14]) ,SYNCHDB_CONNINFO_PASSWORD_SIZE);
 
-	elog(DEBUG1, "name %s hostname %s, port %d, user %s pwd %s srcdb %s "
-			"dstdb %s table %s snapshottable %s connector %s extras(%s %s %s %s %s)",
+	strlcpy(conninfo->jmx.jmx_listenaddr, TextDatumGetCString(res[15]), SYNCHDB_CONNINFO_HOSTNAME_SIZE);
+	conninfo->jmx.jmx_port = atoi(TextDatumGetCString(res[16]));
+	strlcpy(conninfo->jmx.jmx_rmiserveraddr, TextDatumGetCString(res[17]), SYNCHDB_CONNINFO_HOSTNAME_SIZE);
+	conninfo->jmx.jmx_rmiport = atoi(TextDatumGetCString(res[18]));
+	conninfo->jmx.jmx_auth = DatumGetBool(res[19]);
+	strlcpy(conninfo->jmx.jmx_auth_passwdfile, TextDatumGetCString(res[20]), SYNCHDB_METADATA_PATH_SIZE);
+	strlcpy(conninfo->jmx.jmx_auth_accessfile, TextDatumGetCString(res[21]), SYNCHDB_METADATA_PATH_SIZE);
+	conninfo->jmx.jmx_ssl = DatumGetBool(res[22]);
+	strlcpy(conninfo->jmx.jmx_ssl_keystore, TextDatumGetCString(res[23]), SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+	strlcpy(conninfo->jmx.jmx_ssl_keystore_pass, TextDatumGetCString(res[24]), SYNCHDB_CONNINFO_PASSWORD_SIZE);
+	strlcpy(conninfo->jmx.jmx_ssl_truststore, TextDatumGetCString(res[25]), SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+	strlcpy(conninfo->jmx.jmx_ssl_truststore_pass, TextDatumGetCString(res[26]), SYNCHDB_CONNINFO_PASSWORD_SIZE);
+	strlcpy(conninfo->jmx.jmx_exporter, TextDatumGetCString(res[27]), SYNCHDB_METADATA_PATH_SIZE);
+	conninfo->jmx.jmx_exporter_port = atoi(TextDatumGetCString(res[28]));
+	strlcpy(conninfo->jmx.jmx_exporter_conf, TextDatumGetCString(res[29]), SYNCHDB_METADATA_PATH_SIZE);
+
+	elog(LOG, "name=%s hostname=%s, port=%d, user=%s pwd=%s srcdb=%s "
+			"dstdb=%s table=%s snapshottable=%s connector=%s extras(ssl_mode=%s ssl_keystore=%s "
+			"ssl_keystore_pass=%s ssl_truststore=%s ssl_truststore_pass=%s) "
+			"jmx(jmx_listenaddr=%s jmx_port=%d jmx_rmiserveraddr=%s jmx_rmiport=%d "
+			"jmx_auth=%s jmx_auth_passwdfile=%s jmx_auth_accessfile=%s jmx_ssl=%s "
+			"jmx_ssl_keystore=%s jmx_ssl_keystore_pass=%s jmx_ssl_truststore=%s "
+			"jmx_ssl_truststore_pass=%s jmx_exporter=%s jmx_exporter_port=%d "
+			"jmx_exporter_conf=%s)",
 			conninfo->name, conninfo->hostname, conninfo->port,
 			conninfo->user, conninfo->pwd, conninfo->srcdb,
 			conninfo->dstdb, conninfo->table, conninfo->snapshottable, *connector,
 			conninfo->extra.ssl_mode, conninfo->extra.ssl_keystore, conninfo->extra.ssl_keystore_pass,
-			conninfo->extra.ssl_truststore, conninfo->extra.ssl_truststore_pass);
+			conninfo->extra.ssl_truststore, conninfo->extra.ssl_truststore_pass,
+			conninfo->jmx.jmx_listenaddr, conninfo->jmx.jmx_port, conninfo->jmx.jmx_rmiserveraddr,
+			conninfo->jmx.jmx_rmiport, conninfo->jmx.jmx_auth ? "true" : "false",
+			conninfo->jmx.jmx_auth_passwdfile, conninfo->jmx.jmx_auth_accessfile,
+			conninfo->jmx.jmx_ssl ? "true" : "false", conninfo->jmx.jmx_ssl_keystore,
+			conninfo->jmx.jmx_ssl_keystore_pass, conninfo->jmx.jmx_ssl_truststore,
+			conninfo->jmx.jmx_ssl_truststore_pass, conninfo->jmx.jmx_exporter,
+			conninfo->jmx.jmx_exporter_port, conninfo->jmx.jmx_exporter_conf);
 	pfree(res);
 	return 0;
 }

--- a/synchdb--1.0.sql
+++ b/synchdb--1.0.sql
@@ -117,3 +117,18 @@ CREATE OR REPLACE FUNCTION synchdb_del_objmap(name, name, name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION synchdb_add_jmx_conninfo(name, text, int, text, int, bool, text, text, bool, text, text, text, text) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION synchdb_del_jmx_conninfo(name) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION synchdb_add_jmx_exporter_conninfo(name, text, int, text) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION synchdb_del_jmx_exporter_conninfo(name) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;

--- a/synchdb.h
+++ b/synchdb.h
@@ -168,6 +168,36 @@ typedef struct _ExtraConnectionInfo
 } ExtraConnectionInfo;
 
 /**
+ * JMXConnectionInfo - Extra JMX Connector parameters are put here.
+ */
+typedef struct _JMXConnectionInfo
+{
+	/* JMX server options */
+	char jmx_listenaddr[SYNCHDB_CONNINFO_HOSTNAME_SIZE];
+	unsigned int jmx_port;
+	char jmx_rmiserveraddr[SYNCHDB_CONNINFO_HOSTNAME_SIZE];
+	unsigned int jmx_rmiport;
+
+	/* JMX auth options */
+	bool jmx_auth;
+	char jmx_auth_passwdfile[SYNCHDB_METADATA_PATH_SIZE];
+	char jmx_auth_accessfile[SYNCHDB_METADATA_PATH_SIZE];
+
+	/* JMX ssl options */
+	bool jmx_ssl;
+	char jmx_ssl_keystore[SYNCHDB_CONNINFO_KEYSTORE_SIZE];
+	char jmx_ssl_keystore_pass[SYNCHDB_CONNINFO_PASSWORD_SIZE];
+	char jmx_ssl_truststore[SYNCHDB_CONNINFO_KEYSTORE_SIZE];
+	char jmx_ssl_truststore_pass[SYNCHDB_CONNINFO_PASSWORD_SIZE];
+
+	/* JMX exporter options */
+	char jmx_exporter[SYNCHDB_METADATA_PATH_SIZE];
+	unsigned int jmx_exporter_port;
+	char jmx_exporter_conf[SYNCHDB_METADATA_PATH_SIZE];
+
+} JMXConnectionInfo;
+
+/**
  * ConnectionInfo - DBZ Connection info. These are put in shared memory so
  * connector background workers can access when they are spawned.
  */
@@ -186,6 +216,7 @@ typedef struct _ConnectionInfo
     bool isShcemaSync;
     bool isOraCompat; /* added to support ivorysql's oracle compatible mode */
     ExtraConnectionInfo extra;
+    JMXConnectionInfo jmx;
 } ConnectionInfo;
 
 /**


### PR DESCRIPTION
1) added new function synchdb_add_jmx_conninfo to configure jmx endpoint for monitoring with jconsole or similar sort
2) added new function synchdb_add_jmx_exporter_conninfo to configure jmx exporter for prometheus and graphana monitoring
3) fixed a memory context issue when reading connector info at connector startup 
4) fixed dbz_engine install dir to use pkglibdir rather than libdir. This solves the issue when building with custom prefix that synchdb fails to locate dbz_engine from default location.