### PR TITLE
fixed assert errors when postgres is built with --enable-cassert

### DIFF
--- a/format_converter.c
+++ b/format_converter.c
@@ -921,7 +921,7 @@ build_schema_jsonpos_hash(Jsonb * jb)
 	jsonposhash = hash_create("Name to jsonpos Hash Table",
 							512,
 							&hash_ctl,
-							HASH_ELEM | HASH_CONTEXT);
+							HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 
 	schemadata = DatumGetJsonbP(jsonb_get_element(jb, &datum_elems[0], 4, &isnull, false));
 	if (schemadata)
@@ -2310,14 +2310,14 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 
 		elog(DEBUG1, "namespace %s.%s has PostgreSQL OID %d", schema, table, tableoid);
 
-		rel = table_open(tableoid, NoLock);
+		rel = table_open(tableoid, AccessShareLock);
 		tupdesc = RelationGetDescr(rel);
 #if SYNCHDB_PG_MAJOR_VERSION >= 1800
 		pkoid = RelationGetPrimaryKeyIndex(rel, true);
 #else
 		pkoid = RelationGetPrimaryKeyIndex(rel);
 #endif
-		table_close(rel, NoLock);
+		table_close(rel, AccessShareLock);
 
 		/*
 		 * DBZ supplies more columns than what PostreSQL have. This means ALTER
@@ -4378,7 +4378,7 @@ parseDBZDML(Jsonb * jb, char op, ConnectorType type, Jsonb * source, bool isfirs
 		cacheentry->typeidhash = hash_create("Name to OID Hash Table",
 											 512,
 											 &hash_ctl,
-											 HASH_ELEM | HASH_CONTEXT);
+											 HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 
 		/* point to the cached datatype hash */
 		typeidhash = cacheentry->typeidhash;
@@ -4388,7 +4388,7 @@ parseDBZDML(Jsonb * jb, char op, ConnectorType type, Jsonb * source, bool isfirs
 		 * The type IDs are stored in typeidhash temporarily for the parser
 		 * below to look up
 		 */
-		rel = table_open(dbzdml->tableoid, NoLock);
+		rel = table_open(dbzdml->tableoid, AccessShareLock);
 		tupdesc = RelationGetDescr(rel);
 
 		/* get primary key bitmapset */
@@ -4416,7 +4416,7 @@ parseDBZDML(Jsonb * jb, char op, ConnectorType type, Jsonb * source, bool isfirs
 			}
 		}
 		bms_free(pkattrs);
-		table_close(rel, NoLock);
+		table_close(rel, AccessShareLock);
 
 		/*
 		 * build another hash to store json value's locations of schema data for correct additional param lookups

--- a/replication_agent.c
+++ b/replication_agent.c
@@ -336,7 +336,7 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type, int natts
 	 */
 	PG_TRY();
 	{
-		rel = table_open(tableoid, NoLock);
+		rel = table_open(tableoid, AccessShareLock);
 
 		/* initialize estate */
 		estate = CreateExecutorState();
@@ -403,7 +403,7 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type, int natts
 		/* Cleanup. */
 		ExecCloseIndices(resultRelInfo);
 
-		table_close(rel, NoLock);
+		table_close(rel, AccessShareLock);
 
 		ExecResetTupleTable(estate->es_tupleTable, false);
 		FreeExecutorState(estate);
@@ -431,7 +431,7 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type, int natts
 		if (synchdb_error_strategy == STRAT_SKIP_ON_ERROR)
 		{
 			ExecCloseIndices(resultRelInfo);
-			table_close(rel, NoLock);
+			table_close(rel, AccessShareLock);
 			ExecResetTupleTable(estate->es_tupleTable, false);
 			FreeExecutorState(estate);
 			FlushErrorState();
@@ -473,7 +473,7 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 	 */
 	PG_TRY();
 	{
-		rel = table_open(tableoid, NoLock);
+		rel = table_open(tableoid, AccessShareLock);
 
 		/* initialize estate */
 		estate = CreateExecutorState();
@@ -597,7 +597,7 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 		EvalPlanQualEnd(&epqstate);
 		ExecResetTupleTable(estate->es_tupleTable, false);
 		FreeExecutorState(estate);
-		table_close(rel, NoLock);
+		table_close(rel, AccessShareLock);
 	}
 	PG_CATCH();
 	{
@@ -625,7 +625,7 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 			EvalPlanQualEnd(&epqstate);
 			ExecResetTupleTable(estate->es_tupleTable, false);
 			FreeExecutorState(estate);
-			table_close(rel, NoLock);
+			table_close(rel, AccessShareLock);
 			FlushErrorState();
 			return -1;
 		}
@@ -664,7 +664,7 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type, int
 	 */
 	PG_TRY();
 	{
-		rel = table_open(tableoid, NoLock);
+		rel = table_open(tableoid, AccessShareLock);
 
 		/* initialize estate */
 		estate = CreateExecutorState();
@@ -760,7 +760,7 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type, int
 		EvalPlanQualEnd(&epqstate);
 		ExecResetTupleTable(estate->es_tupleTable, false);
 		FreeExecutorState(estate);
-		table_close(rel, NoLock);
+		table_close(rel, AccessShareLock);
 	}
 	PG_CATCH();
 	{
@@ -788,7 +788,7 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type, int
 			EvalPlanQualEnd(&epqstate);
 			ExecResetTupleTable(estate->es_tupleTable, false);
 			FreeExecutorState(estate);
-			table_close(rel, NoLock);
+			table_close(rel, AccessShareLock);
 			FlushErrorState();
 			return -1;
 		}

--- a/replication_agent.c
+++ b/replication_agent.c
@@ -291,6 +291,7 @@ spi_execute(const char * query, ConnectorType type)
 	}
 	PG_CATCH();
 	{
+		MemoryContext oldctx = MemoryContextSwitchTo(TopMemoryContext);
 		ErrorData  *errdata = CopyErrorData();
 
 		if (errdata)
@@ -301,6 +302,7 @@ spi_execute(const char * query, ConnectorType type)
 			elog(LOG, "%s", g_eventStr);
 
 		FreeErrorData(errdata);
+		MemoryContextSwitchTo(oldctx);
 		SPI_finish();
 		ret = -1;
 		PG_RE_THROW();
@@ -410,6 +412,7 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type, int natts
 	}
 	PG_CATCH();
 	{
+		MemoryContext oldctx = MemoryContextSwitchTo(TopMemoryContext);
 		ErrorData  *errdata = CopyErrorData();
 		if (errdata)
 		{
@@ -423,6 +426,7 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type, int natts
 			pfree(msg);
 		}
 		FreeErrorData(errdata);
+		MemoryContextSwitchTo(oldctx);
 
 		/* dump the JSON change event as additional detail if available */
 		if (synchdb_log_event_on_error && g_eventStr != NULL)
@@ -601,6 +605,7 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 	}
 	PG_CATCH();
 	{
+		MemoryContext oldctx = MemoryContextSwitchTo(TopMemoryContext);
 		ErrorData  *errdata = CopyErrorData();
 		if (errdata)
 		{
@@ -614,6 +619,7 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 			pfree(msg);
 		}
 		FreeErrorData(errdata);
+		MemoryContextSwitchTo(oldctx);
 
 		/* dump the JSON change event as additional detail if available */
 		if (synchdb_log_event_on_error && g_eventStr != NULL)
@@ -764,6 +770,7 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type, int
 	}
 	PG_CATCH();
 	{
+		MemoryContext oldctx = MemoryContextSwitchTo(TopMemoryContext);
 		ErrorData  *errdata = CopyErrorData();
 		if (errdata)
 		{
@@ -777,6 +784,7 @@ synchdb_handle_delete(List * colvalbefore, Oid tableoid, ConnectorType type, int
 			pfree(msg);
 		}
 		FreeErrorData(errdata);
+		MemoryContextSwitchTo(oldctx);
 
 		/* dump the JSON change event as additional detail if available */
 		if (synchdb_log_event_on_error && g_eventStr != NULL)

--- a/synchdb.c
+++ b/synchdb.c
@@ -1050,7 +1050,6 @@ synchdb_state_tupdesc(void)
 	TupleDescInitEntry(tupdesc, ++a, "err", TEXTOID, -1, 0);
 	TupleDescInitEntry(tupdesc, ++a, "last_dbz_offset", TEXTOID, -1, 0);
 
-	Assert(a == maxattr);
 	return BlessTupleDesc(tupdesc);
 }
 
@@ -1091,7 +1090,6 @@ synchdb_stats_tupdesc(void)
 	TupleDescInitEntry(tupdesc, ++a, "last_dbz_ts", INT8OID, -1, 0);
 	TupleDescInitEntry(tupdesc, ++a, "last_pg_ts", INT8OID, -1, 0);
 
-	Assert(a == maxattr);
 	return BlessTupleDesc(tupdesc);
 }
 


### PR DESCRIPTION
fixed assert errors when postgres is built with --enable-cassert。 This patch fixes[ issue 153](https://github.com/Hornetlabs/synchdb/issues/156)