### PR TITLE
added ezdeploy.sh for quick deploy + test

### DIFF
--- a/ci/setup-remotedbs.sh
+++ b/ci/setup-remotedbs.sh
@@ -6,8 +6,6 @@ set -euo pipefail
 DBTYPE=${DBTYPE:?please provide database type via DBTYPE env variable}
 INTERNAL=${INTERNAL:?please indicate if containers should be deployed as internal via INTERNAL env variable (0 or 1)}
 
-echo INTERNAL=$INTERNAL
-
 basedir="$(pwd)"
 MAX_TRIES=200
 
@@ -19,15 +17,16 @@ function wait_for_container_ready()
 	ready=0
 
 	set +e
-	docker ps | grep $name > /dev/null
-	if [ $? -ne 0 ]; then
+	if ! docker inspect $name >/dev/null 2>&1; then
 		echo "$name is not running or failed to start!"
+		return
 	fi	
 
 	for ((i=1; i<=MAX_TRIES; i++));
 	do
 		docker logs "$name" 2>&1 | grep "$keyword"
 		if [ $? -eq 0 ]; then
+		#if docker logs "$name" 2>/dev/null | grep "$keyword"; then
 			echo "$name is ready to use"
 			ready=1
 			break
@@ -77,9 +76,9 @@ function setup_sqlserver()
 	fi
 	echo "sleep to give container time to startup..."
 	sleep 30  # Give containers time to fully start
-	docker cp ./testenv/sqlserver/inventory.sql sqlserver:/
-	docker exec -i sqlserver /opt/mssql-tools18/bin/sqlcmd -U sa -P 'Password!' -C -Q "SELECT @@VERSION" > /dev/null
-	docker exec -i sqlserver /opt/mssql-tools18/bin/sqlcmd -U sa -P 'Password!' -C -i /inventory.sql > /dev/null
+	docker cp ./testenv/sqlserver/inventory.sql sqlserver:/  >/dev/null 2>&1
+	docker exec -i sqlserver /opt/mssql-tools18/bin/sqlcmd -U sa -P 'Password!' -C -Q "SELECT @@VERSION"  >/dev/null 2>&1
+	docker exec -i sqlserver /opt/mssql-tools18/bin/sqlcmd -U sa -P 'Password!' -C -i /inventory.sql  >/dev/null 2>&1
 	exit 0
 }
 
@@ -89,8 +88,9 @@ function setup_oracle()
 
 	set +e
 	echo "setting up oracle..."
-	docker ps -a | grep "oracle" | grep -v oracle-19c > /dev/null
-	if [ $? -ne 0 ]; then
+	#docker ps -a | grep "oracle" | grep -v oracle-19c > /dev/null
+	#if [ $? -ne 0 ]; then
+	if ! docker ps -a --format '{{.Names}}' | grep -q "oracle"; then
         # container has not run before. Run a new one
 		if [ $INTERNAL -eq 1 ]; then
         	docker-compose -f testenv/oracle/synchdb-oracle-test-internal.yaml up -d
@@ -100,17 +100,15 @@ function setup_oracle()
 		wait_for_container_ready "oracle" "DATABASE IS READY TO USE"
         needsetup=1
     else
-        docker ps -a | grep "oracle" | grep -i "Exited" > /dev/null
-        if [ $? -eq 0 ]; then
-            # container has been run before but stopped. Start it
-            docker start oracle
-            wait_for_container_ready "oracle" "DATABASE IS READY TO USE"
+		state=$(docker inspect -f '{{.State.Status}}' oracle 2>/dev/null || echo unknown)
+		if [ $state == "running" ]; then
+            echo "oracle23ai is already running..."
+        elif [ $state == "exited" ]; then
+            echo "oracle23ai exited, starting it again..."
+            docker start oracle >/dev/null 2>&1
+			wait_for_container_ready "oracle" "DATABASE IS READY TO USE"
         else
-            docker ps -a | grep "oracle" | grep -i "Up" > /dev/null
-            if [ $? -eq 0 ]; then
-                # container is running. Just use it
-                echo "using exisitng oracle 19c container..."
-            fi
+            echo "oracle23ai in unknown state. Remove it and try again..."
         fi
 		return
     fi
@@ -239,8 +237,9 @@ function setup_ora19c()
 
 	set +e
 	echo "setting up oracle 19c..."
-	docker ps -a | grep "ora19c" > /dev/null
-	if [ $? -ne 0 ]; then
+	#docker ps -a | grep "ora19c" > /dev/null
+	#if [ $? -ne 0 ]; then
+	if ! docker ps -a --format '{{.Names}}' | grep -q "ora19c"; then
 		# container has not run before. Run a new one
 		if [ "$forolr" == "olr" ]; then
 			if [ $INTERNAL -eq 1 ]; then
@@ -258,18 +257,16 @@ function setup_ora19c()
 		wait_for_container_ready "ora19c" "DATABASE IS READY TO USE"
 		needsetup=1	
 	else
-		docker ps -a | grep "ora19c" | grep -i "Exited" > /dev/null
-		if [ $? -eq 0 ]; then
-			# container has been run before but stopped. Start it
-			docker start ora19c
+		state=$(docker inspect -f '{{.State.Status}}' ora19c 2>/dev/null || echo unknown)
+		if [ $state == "running" ]; then
+            echo "oracle19c is already running..."
+        elif [ $state == "exited" ]; then
+            echo "oracle19c exited, starting it again..."
+            docker start ora19c >/dev/null 2>&1
 			wait_for_container_ready "ora19c" "DATABASE IS READY TO USE"
-		else
-			docker ps -a | grep "ora19c" | grep -i "Up" > /dev/null
-			if [ $? -eq 0 ]; then
-				# container is running. Just use it
-				echo "using exisitng oracle 19c container..."
-			fi
-		fi
+        else
+            echo "oracle19c in unknown state. Remove it and try again..."
+        fi
 		return
 	fi
 
@@ -415,13 +412,8 @@ function setup_hammerdb()
 	exit 0
 }
 
-function setup_oranet_and_oradata()
+function setup_oradata()
 {
-	#docker network inspect oranet >/dev/null 2>&1
-	#if [ $? -ne 0 ]; then
-	#	docker network create oranet
-	#fi
-
 	if [ ! -d ./testenv/olr/oradata ]; then
 		mkdir ./testenv/olr/oradata
 		sudo chown 54321:54321 -R ./testenv/olr/oradata
@@ -437,8 +429,9 @@ function setup_olr()
 {
 	echo "setting up openlog replicator $OLRVER..."
 
-	docker ps -a | grep "OpenLogReplicator" >/dev/null
-    if [ $? -ne 0 ]; then
+	#docker ps -a | grep "OpenLogReplicator" >/dev/null
+    #if [ $? -ne 0 ]; then
+	if ! docker ps -a --format '{{.Names}}' | grep -q "OpenLogReplicator"; then
 		docker-compose -f testenv/olr/synchdb-olr-test.yaml up -d
 #		docker run -d --name OpenLogReplicator \
 #			--network synchdbnet \
@@ -450,17 +443,15 @@ function setup_olr()
 #			--user 54321 \
 #			hgneon/openlogreplicator:$OLRVER
 	else
-        docker ps -a | grep "OpenLogReplicator" | grep -i "Exited" > /dev/null
-        if [ $? -eq 0 ]; then
-            # container has been run before but stopped. Start it
-			echo "starting OpenLogReplicator..."
-            docker start OpenLogReplicator
-			sleep 15
+		state=$(docker inspect -f '{{.State.Status}}' OpenLogReplicator 2>/dev/null || echo unknown)
+        #docker ps -a | grep "OpenLogReplicator" | grep -i "Exited" > /dev/null
+        if [ $state == "running" ]; then
+			echo "openlog repliator is already running..."
+		elif [ $state == "exited" ]; then
+			echo "OpenLogReplicator exited, starting it again..."
+            docker start OpenLogReplicator >/dev/null 2>&1
         else
-            docker ps -a | grep "OpenLogReplicator" | grep -i "Up" > /dev/null
-            if [ $? -eq 0 ]; then
-				echo "openlog repliator is already running..."
-            fi
+			echo "OpenLogReplicator in unknown state. Remove it and try again..."
         fi
     fi
 }
@@ -487,7 +478,7 @@ function setup_remotedb()
 			;;
 		"olr")
 			OLRVER=${OLRVER:?please provide OLR version via OLRVER env variable}
-			setup_oranet_and_oradata
+			setup_oradata
 			setup_ora19c "olr"
 			setup_olr
 			;;

--- a/ci/teardown-remotedbs.sh
+++ b/ci/teardown-remotedbs.sh
@@ -65,7 +65,7 @@ function teardown_olr()
 function teardown_oradata()
 {
     if [ -d ./testenv/olr/oradata ]; then
-        sudo rm -r /testenv/olr/oradata
+        sudo rm -r ./testenv/olr/oradata
     fi
 
     if [ -d ./testenv/olr/checkpoint ]; then

--- a/ci/teardown-remotedbs.sh
+++ b/ci/teardown-remotedbs.sh
@@ -64,6 +64,7 @@ function teardown_olr()
 
 function teardown_oradata()
 {
+	echo "tearing down oradata..."
     if [ -d ./testenv/olr/oradata ]; then
         sudo rm -r ./testenv/olr/oradata
     fi
@@ -106,6 +107,9 @@ function teardown_remotedb()
 			;;
 		"synchdbnet")
 			teardown_synchdbnet
+			;;
+		"oradata")
+			teardown_oradata
 			;;
 		*)
 			echo "$dbtype not supported"

--- a/ci/teardown-remotedbs.sh
+++ b/ci/teardown-remotedbs.sh
@@ -18,8 +18,8 @@ basedir="$(pwd)"
 function teardown_mysql()
 {
 	echo "tearing down mysql..."
-	docker stop mysql
-	docker rm mysql
+	docker stop mysql >/dev/null 2>&1
+	docker rm mysql >/dev/null 2>&1
 	#docker-compose -f testenv/mysql/synchdb-mysql-test.yaml down
 }
 
@@ -27,45 +27,56 @@ function teardown_sqlserver()
 {
 
 	echo "tearing down sqlserver..."
-	docker stop sqlserver
-	docker rm sqlserver
+	docker stop sqlserver >/dev/null 2>&1
+	docker rm sqlserver >/dev/null 2>&1
 	#docker-compose -f testenv/sqlserver/synchdb-sqlserver-test.yaml down
 }
 
 function teardown_oracle()
 {
 	echo "tearing down oracle..."
-	docker stop oracle
-	docker rm oracle
+	docker stop oracle >/dev/null 2>&1
+	docker rm oracle >/dev/null 2>&1
 	#docker-compose -f testenv/oracle/synchdb-oracle-test.yaml down
 }
 
 function teardown_ora19c()
 {
 	echo "tearing down ora19c..."
-	docker stop ora19c
-	docker rm ora19c
+	docker stop ora19c >/dev/null 2>&1
+	docker rm ora19c >/dev/null 2>&1
 }
 
 function teardown_hammerdb()
 {
 	echo "tearing down hammerdb..."
-	docker stop	hammerdb
-	docker rm hammerdb
+	docker stop	hammerdb >/dev/null 2>&1
+	docker rm hammerdb >/dev/null 2>&1
 }
 
 function teardown_olr()
 {
 	echo "tearing down olr..."
-	docker stop OpenLogReplicator
-	docker rm OpenLogReplicator
+	docker stop OpenLogReplicator >/dev/null 2>&1
+	docker rm OpenLogReplicator >/dev/null 2>&1
 	#docker-compose -f testenv/olr/synchdb-olr-test.yaml down
+}
+
+function teardown_oradata()
+{
+    if [ -d ./testenv/olr/oradata ]; then
+        sudo rm -r /testenv/olr/oradata
+    fi
+
+    if [ -d ./testenv/olr/checkpoint ]; then
+        sudo rm -r ./testenv/olr/checkpoint
+    fi
 }
 
 function teardown_synchdbnet()
 {
 	echo "tearing down synchdbnet..."
-	docker network rm synchdbnet
+	docker network rm synchdbnet >/dev/null 2>&1
 }
 
 function teardown_remotedb()
@@ -91,7 +102,7 @@ function teardown_remotedb()
 		"olr")
 			teardown_olr
 			teardown_ora19c
-			teardown_synchdbnet
+			teardown_oradata
 			;;
 		"synchdbnet")
 			teardown_synchdbnet

--- a/ezdeploy.sh
+++ b/ezdeploy.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+set -euo pipefail
+
+OLRVER="1.3.0"
+
+function have()
+{
+	command -v "$1" >/dev/null 2>&1;
+}
+
+function deploy-synchdb()
+{
+	echo "setting up synchdb..."
+	if docker ps -a --format '{{.Names}}' | grep -q "synchdb"; then
+		echo "synchdb already exists: skip it..."
+	else
+		docker-compose -f ./testenv/synchdb/synchdb-test.yaml up -d
+	fi
+}
+
+function teardown-synchdb()
+{
+	echo "tearing down synchdb..."
+    if docker ps -a --format '{{.Names}}' | grep -q "synchdb"; then
+        docker stop synchdb >/dev/null 2>&1
+        docker rm synchdb >/dev/null 2>&1
+    fi
+	#docker-compose -f ./testenv/synchdb/synchdb-test.yaml down
+}
+
+function deploy-sourcedb()
+{
+	if [ $1 == "olr" ]; then
+		DBTYPE=$1 INTERNAL=1 OLRVER=$OLRVER ./ci/setup-remotedbs.sh
+	else
+		DBTYPE=$1 INTERNAL=1 ./ci/setup-remotedbs.sh
+	fi
+}
+
+function teardown-sourcedb()
+{
+	echo "tearing down $1 if active..."
+	if [ $1 == "olr" ]; then
+		name="OpenLogReplicator"
+	else
+		name=$1
+	fi
+
+	if docker ps -a --format '{{.Names}}' | grep -q "$name"; then
+		DBTYPE=$1 ./ci/teardown-remotedbs.sh	
+	fi
+}
+
+function custom-deployment()
+{
+	echo ""
+	echo "please list source databases separate by comma"
+    echo "possible values: (mysql, sqlserver, oracle23ai, oracle19c, olr)"
+
+	read -rp "your selection: " RAW_CHOICES
+	IFS=', ' read -r -a _tokens <<< "$RAW_CHOICES"
+	declare -A PICKED=()
+	for t in "${_tokens[@]}"; do
+		[[ -z "$t" ]] && continue
+		key="${t,,}"
+		case "$key" in
+			mysql|sqlserver|oracle23ai|oracle19c|olr) PICKED["$key"]=1 ;;
+		*) echo "Ignoring unknown option: $t" ;;
+		esac
+	done
+
+	if [[ "${#PICKED[@]}" -eq 0 ]]; then
+		echo "No valid selections made. We'll deploy only 'synchdb'."
+		FINAL_LIST="synchdb"
+	else
+
+		if [[ -n "${PICKED[oracle19c]+x}" && -n "${PICKED[olr]+x}" ]]; then
+			echo "Ignoring oracle19c because olr will also deploy oracle19c"
+			unset PICKED[oracle19c]
+		fi
+
+		FINAL_LIST="synchdb $(printf '%s ' "${!PICKED[@]}" | sed 's/ $//')"
+	fi
+
+	#echo "About to deploy: $FINAL_LIST"
+	for x in $FINAL_LIST;
+	do
+		if [ $x == "synchdb" ]; then
+			deploy-synchdb
+			continue
+		fi
+
+		if [ $x == "oracle23ai" ]; then
+			x="oracle"
+		fi
+
+		if [ $x == "oracle19c" ]; then
+			x="ora19c"
+		fi
+
+		deploy-sourcedb $x
+		
+		#echo "deploying $x ..."
+	done
+}
+
+
+# check required tools
+if ! have docker; then
+	echo "docker is missing. Exit..."
+	exit 1
+fi
+
+if ! have docker-compose; then
+
+	# eheck if docker compose is available
+	docker compose >/dev/null 2>&1
+	if [ $? -ne 0 ]; then 
+		echo "docker-compose is missing. Exit..."
+		exit 1
+	else
+		echo "docker compose is available, but not docker-compose. Please create an alias and try again."
+		echo "example: alias docker-compose=\"docker compose\"" 
+		exit 1
+	fi
+fi
+
+# check required scripts
+if [ ! -f ./ci/setup-remotedbs.sh ] || [ ! -f ./ci/teardown-remotedbs.sh ]; then
+	echo "please run this script in the root directory of synchdb project"
+	exit 1
+fi
+
+# prompts
+
+echo "----------------------------------"
+echo "-----> Welcome to ezdeploy! <-----"
+echo "----------------------------------"
+echo ""
+echo "please select a quick deploy option:"
+echo -e "\t1) synchdb only"
+echo -e "\t2) synchdb + mysql"
+echo -e "\t3) synchdb + sqlserver"
+echo -e "\t4) synchdb + oracle23ai"
+echo -e "\t5) synchdb + oracle19c"
+echo -e "\t6) synchdb + olr(oracle19c)"
+echo -e "\t7) synchdb + all source databases"
+echo -e "\t8) custom deployment"
+echo -e "\t9) teardown deployment"
+
+read -rp "enter your selection: " choice
+
+case "$choice" in
+  1) deploy-synchdb
+	 ;;
+  2) deploy-synchdb
+	 deploy-sourcedb "mysql"
+	 ;;
+  3) deploy-synchdb
+	 deploy-sourcedb "sqlserver"
+	 ;;
+  4) deploy-synchdb
+	 deploy-sourcedb "oracle"
+	 ;;
+  5) deploy-synchdb
+	 deploy-sourcedb "ora19c"
+	 ;;
+  6) deploy-synchdb
+	 deploy-sourcedb "olr"
+	 ;;
+  7) deploy-synchdb
+	 deploy-sourcedb "mysql"
+	 deploy-sourcedb "sqlserver" 
+	 deploy-sourcedb "oracle" 
+	 deploy-sourcedb "olr"
+	 ;;
+  8) custom-deployment 
+	 ;;
+  9) teardown-synchdb
+	 teardown-sourcedb "mysql"
+	 teardown-sourcedb "sqlserver" 
+	 teardown-sourcedb "oracle" 
+	 teardown-sourcedb "ora19c" 
+	 teardown-sourcedb "olr"
+	 teardown-sourcedb "synchdbnet"
+	 ;;
+  *) echo "Invalid choice"; exit 1
+	 ;;
+esac
+
+echo "job done..."

--- a/testenv/oracle/synchdb-oracle-test.yaml
+++ b/testenv/oracle/synchdb-oracle-test.yaml
@@ -6,5 +6,5 @@ services:
   oracle:
     container_name: oracle
     image: hgneon/testdb-oracle:23ai
-      ports:
+    ports:
       - 1521:1521


### PR DESCRIPTION
added new tool called ezdeploy.sh that can be used to deploy a pre-compiled synchdb and prepare a test source databases (mysql, sqlserver, oracle, olr)  to run some quick test. 

Details of how to use the tool will be included in the documentation page

also fixed olr netio_connect to work with hostname / ipv6 addresses