### PR TITLE
infinispan support for oracle debezium connector to support large transaction handling

### DIFF
--- a/src/backend/debezium/src/main/java/com/example/DebeziumRunner.java
+++ b/src/backend/debezium/src/main/java/com/example/DebeziumRunner.java
@@ -362,7 +362,7 @@ public class DebeziumRunner {
 		String offsetfile = null;
 		String schemahistoryfile = null;
 		String signalfile = null;
-		String ispn_metadata_prefix = null;
+		String ispn_metadata_dir = null;
 		
 		Properties props = new Properties();
 
@@ -469,7 +469,7 @@ public class DebeziumRunner {
 				offsetfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_" + myParameters.dstdb + "_offsets.dat";
 				schemahistoryfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_" + myParameters.dstdb + "_schemahistory.dat";
 				signalfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_" + myParameters.dstdb + "_signal.dat";
-				ispn_metadata_prefix = "pg_synchdb/ispn_" + myParameters.connectorName + "_" + myParameters.dstdb;
+				ispn_metadata_dir = "pg_synchdb/ispn_" + myParameters.connectorName + "_" + myParameters.dstdb;
 
                 props.setProperty("database.dbname", myParameters.database);
 				if (myParameters.database.equals("null"))
@@ -500,14 +500,13 @@ public class DebeziumRunner {
 				{
 					String memtype = "HEAP";
 
-					if (myParameters.ispnCacheType == "embedded")
+					if (myParameters.ispnCacheType.equals("embedded"))
 						props.setProperty("log.mining.buffer.type", "infinispan_embedded");
 					else
 						/* todo: we always default to embedded as that is the mode we support now */
 						props.setProperty("log.mining.buffer.type", "infinispan_embedded");
 	
-					if (myParameters.ispnMemoryType.equals("off heap") ||
-					    myParameters.ispnMemoryType.equals("off_heap"))
+					if (myParameters.ispnMemoryType.equals("off heap"))
 						memtype = "OFF_HEAP";
 					else if (myParameters.ispnMemoryType.equals("heap"))
 						memtype = "HEAP";
@@ -535,8 +534,8 @@ public class DebeziumRunner {
 					    "<memory storage=\"" + memtype + "\" max-size=\"" + myParameters.ispnMemorySize + "MB\" when-full=\"REMOVE\"/>" +
 					    "<persistence passivation=\"true\">" +
 					      "<file-store read-only=\"false\" preload=\"false\" shared=\"false\">" +
-					        "<data path=\"" + ispn_metadata_prefix + "/events/data\"/>" +
-				    	    "<index path=\"" + ispn_metadata_prefix + "/events/index\"/>" +
+					        "<data path=\"" + ispn_metadata_dir + "/events/data\"/>" +
+				    	    "<index path=\"" + ispn_metadata_dir + "/events/index\"/>" +
 				        	"<write-behind/>" +
 					      "</file-store>" +
 					    "</persistence>" +
@@ -554,8 +553,8 @@ public class DebeziumRunner {
 					    "<memory storage=\"" + memtype + "\" max-size=\"" + myParameters.ispnMemorySize +"MB\" when-full=\"REMOVE\"/>" +
 				    	"<persistence passivation=\"true\">" +
 					      "<file-store read-only=\"false\" preload=\"false\" shared=\"false\">" +
-					        "<data path=\"" + ispn_metadata_prefix + "/transactions/data\"/>" +
-					        "<index path=\"" + ispn_metadata_prefix + "/transactions/index\"/>" +
+					        "<data path=\"" + ispn_metadata_dir + "/transactions/data\"/>" +
+					        "<index path=\"" + ispn_metadata_dir + "/transactions/index\"/>" +
 					        "<write-behind/>" +
 					      "</file-store>" +
 				    	"</persistence>" +
@@ -573,8 +572,8 @@ public class DebeziumRunner {
 				    	"<memory storage=\"" + memtype + "\" max-size=\"" + myParameters.ispnMemorySize +"MB\" when-full=\"REMOVE\"/>" +
 					    "<persistence passivation=\"true\">" +
 					      "<file-store read-only=\"false\" preload=\"false\" shared=\"false\">" +
-					        "<data path=\"" + ispn_metadata_prefix + "/processed/data\"/>" +
-					        "<index path=\"" + ispn_metadata_prefix + "/processed/index\"/>" +
+					        "<data path=\"" + ispn_metadata_dir + "/processed/data\"/>" +
+					        "<index path=\"" + ispn_metadata_dir + "/processed/index\"/>" +
 					        "<write-behind/>" +
 				    	  "</file-store>" +
 					    "</persistence>" +
@@ -592,8 +591,8 @@ public class DebeziumRunner {
 					    "<memory storage=\"" + memtype + "\" max-size=\"" + myParameters.ispnMemorySize + "MB\" when-full=\"REMOVE\"/>" +
 					    "<persistence passivation=\"true\">" +
 					      "<file-store read-only=\"false\" preload=\"false\" shared=\"false\">" +
-				    	    "<data path=\"" + ispn_metadata_prefix + "/schema/data\"/>" +
-					        "<index path=\"" + ispn_metadata_prefix + "/schema/index\"/>" +
+				    	    "<data path=\"" + ispn_metadata_dir + "/schema/data\"/>" +
+					        "<index path=\"" + ispn_metadata_dir + "/schema/index\"/>" +
 					        "<write-behind/>" +
 					      "</file-store>" +
 					    "</persistence>" +

--- a/src/backend/debezium/src/main/java/com/example/DebeziumRunner.java
+++ b/src/backend/debezium/src/main/java/com/example/DebeziumRunner.java
@@ -103,6 +103,9 @@ public class DebeziumRunner {
 		private String olrHost;
 		private int olrPort;
 		private String olrSource;
+		private String ispnCacheType;
+		private String ispnMemoryType;
+		private int ispnMemorySize;
 
 		/* constructor requires all required parameters for a connector to work */
 		public MyParameters(String connectorName, int connectorType, String hostname, int port, String user, String password, String database, String table, String snapshottable,String snapshotMode, String dstdb)
@@ -216,6 +219,13 @@ public class DebeziumRunner {
 			this.olrSource = olrSource;
 			return this;
 		}
+		public MyParameters setIspn(String ispnCacheType, String ispnMemoryType, int ispnMemorySize)
+		{
+			this.ispnCacheType = ispnCacheType;
+			this.ispnMemoryType = ispnMemoryType;
+			this.ispnMemorySize = ispnMemorySize;
+			return this;
+		}
 
 		/* add more setters here to incrementally set parameters */
 		public void print()
@@ -253,7 +263,10 @@ public class DebeziumRunner {
 			logger.warn("olrHost = " + this.olrHost);
 			logger.warn("olrPort = " + this.olrPort);
 			logger.warn("olrSource = " + this.olrSource);
-
+			
+			logger.warn("ispnCacheType = " + this.ispnCacheType);
+			logger.warn("ispnMemoryType = " + this.ispnMemoryType);
+			logger.warn("ispnMemorySize = " + this.ispnMemorySize);
 		}
 
 	}
@@ -346,17 +359,23 @@ public class DebeziumRunner {
 
 	public void startEngine(MyParameters myParameters) throws Exception
 	{
-		String offsetfile = "/dev/shm/offsets.dat";
-		String schemahistoryfile = "/dev/shm/schemahistory.dat";
-		String signalfile= "/dev/shm/signalfile.dat";
+		String offsetfile = null;
+		String schemahistoryfile = null;
+		String signalfile = null;
+		String ispn_metadata_prefix = null;
+		
 		Properties props = new Properties();
 
 		/* Initialize Logging */
-		ConsoleAppender consoleAppender = new ConsoleAppender();
-        consoleAppender.setLayout(new PatternLayout("%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n"));
-        consoleAppender.setTarget(ConsoleAppender.SYSTEM_OUT);
-        consoleAppender.activateOptions();
-		logger.addAppender(consoleAppender);
+		if (logger.getAppender("Console") == null)
+		{
+			ConsoleAppender consoleAppender = new ConsoleAppender();
+			consoleAppender.setName("Console");
+        	consoleAppender.setLayout(new PatternLayout("%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n"));
+        	consoleAppender.setTarget(ConsoleAppender.SYSTEM_OUT);
+        	consoleAppender.activateOptions();
+			logger.addAppender(consoleAppender);
+		}
 
 		switch (myParameters.logLevel)
 		{
@@ -450,6 +469,7 @@ public class DebeziumRunner {
 				offsetfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_" + myParameters.dstdb + "_offsets.dat";
 				schemahistoryfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_" + myParameters.dstdb + "_schemahistory.dat";
 				signalfile = "pg_synchdb/oracle_" + myParameters.connectorName + "_" + myParameters.dstdb + "_signal.dat";
+				ispn_metadata_prefix = "pg_synchdb/ispn_" + myParameters.connectorName + "_" + myParameters.dstdb;
 
                 props.setProperty("database.dbname", myParameters.database);
 				if (myParameters.database.equals("null"))
@@ -474,6 +494,112 @@ public class DebeziumRunner {
         		else
             		logger.warn("olrHost is null - skip setting Openlog Replicator property");
 
+				if (myParameters.ispnCacheType != null &&
+					myParameters.ispnMemoryType != null &&
+					myParameters.ispnMemorySize > 0)
+				{
+					String memtype = "HEAP";
+
+					if (myParameters.ispnCacheType == "embedded")
+						props.setProperty("log.mining.buffer.type", "infinispan_embedded");
+					else
+						/* todo: we always default to embedded as that is the mode we support now */
+						props.setProperty("log.mining.buffer.type", "infinispan_embedded");
+	
+					if (myParameters.ispnMemoryType.equals("off heap") ||
+					    myParameters.ispnMemoryType.equals("off_heap"))
+						memtype = "OFF_HEAP";
+					else if (myParameters.ispnMemoryType.equals("heap"))
+						memtype = "HEAP";
+					else
+						memtype = "HEAP";
+					
+					logger.warn("using infinispan with memtype " + memtype);
+					props.setProperty(
+				  	"log.mining.buffer.infinispan.cache.global",
+					  "<infinispan xmlns=\"urn:infinispan:config:14.0\">" +
+					    "<threads>" +
+					      "<blocking-bounded-queue-thread-pool name=\"myexec\" max-threads=\"10\" keepalive-time=\"10000\" queue-length=\"5000\"/>" +
+					    "</threads>" +
+					  "</infinispan>"
+					);
+
+					/* EVENT cache */
+					props.setProperty(
+					  "log.mining.buffer.infinispan.cache.events",
+					  "<local-cache name=\"events\">" +
+					    "<encoding>" +
+					      "<key media-type=\"application/x-protostream\"/>" +
+				    	  "<value media-type=\"application/x-protostream\"/>" +
+					    "</encoding>" +
+					    "<memory storage=\"" + memtype + "\" max-size=\"" + myParameters.ispnMemorySize + "MB\" when-full=\"REMOVE\"/>" +
+					    "<persistence passivation=\"true\">" +
+					      "<file-store read-only=\"false\" preload=\"false\" shared=\"false\">" +
+					        "<data path=\"" + ispn_metadata_prefix + "/events/data\"/>" +
+				    	    "<index path=\"" + ispn_metadata_prefix + "/events/index\"/>" +
+				        	"<write-behind/>" +
+					      "</file-store>" +
+					    "</persistence>" +
+					  "</local-cache>"
+					);
+
+					/* TRANSACTIONS cache */
+					props.setProperty(
+					  "log.mining.buffer.infinispan.cache.transactions",
+					  "<local-cache name=\"transactions\">" +
+					    "<encoding>" +
+					      "<key media-type=\"application/x-protostream\"/>" +
+					      "<value media-type=\"application/x-protostream\"/>" +
+					    "</encoding>" +
+					    "<memory storage=\"" + memtype + "\" max-size=\"" + myParameters.ispnMemorySize +"MB\" when-full=\"REMOVE\"/>" +
+				    	"<persistence passivation=\"true\">" +
+					      "<file-store read-only=\"false\" preload=\"false\" shared=\"false\">" +
+					        "<data path=\"" + ispn_metadata_prefix + "/transactions/data\"/>" +
+					        "<index path=\"" + ispn_metadata_prefix + "/transactions/index\"/>" +
+					        "<write-behind/>" +
+					      "</file-store>" +
+				    	"</persistence>" +
+					  "</local-cache>"
+					);
+
+					/* PROCESSED TRANSACTIONS cache */
+					props.setProperty(
+					  "log.mining.buffer.infinispan.cache.processed_transactions",
+					  "<local-cache name=\"processed-transactions\">" +
+					    "<encoding>" +
+					      "<key media-type=\"application/x-protostream\"/>" +
+					      "<value media-type=\"application/x-protostream\"/>" +
+					    "</encoding>" +
+				    	"<memory storage=\"" + memtype + "\" max-size=\"" + myParameters.ispnMemorySize +"MB\" when-full=\"REMOVE\"/>" +
+					    "<persistence passivation=\"true\">" +
+					      "<file-store read-only=\"false\" preload=\"false\" shared=\"false\">" +
+					        "<data path=\"" + ispn_metadata_prefix + "/processed/data\"/>" +
+					        "<index path=\"" + ispn_metadata_prefix + "/processed/index\"/>" +
+					        "<write-behind/>" +
+				    	  "</file-store>" +
+					    "</persistence>" +
+					  "</local-cache>"
+					);
+
+					/* SCHEMA CHANGES cache */
+					props.setProperty(
+					  "log.mining.buffer.infinispan.cache.schema_changes",
+					  "<local-cache name=\"schema-changes\">" +
+					    "<encoding>" +
+				    	  "<key media-type=\"application/x-protostream\"/>" +
+					      "<value media-type=\"application/x-protostream\"/>" +
+					    "</encoding>" +
+					    "<memory storage=\"" + memtype + "\" max-size=\"" + myParameters.ispnMemorySize + "MB\" when-full=\"REMOVE\"/>" +
+					    "<persistence passivation=\"true\">" +
+					      "<file-store read-only=\"false\" preload=\"false\" shared=\"false\">" +
+				    	    "<data path=\"" + ispn_metadata_prefix + "/schema/data\"/>" +
+					        "<index path=\"" + ispn_metadata_prefix + "/schema/index\"/>" +
+					        "<write-behind/>" +
+					      "</file-store>" +
+					    "</persistence>" +
+					  "</local-cache>"
+					);
+				}
 				break;
 			}
 			case TYPE_OPENLOG_REPLICATOR:
@@ -933,7 +1059,7 @@ public class DebeziumRunner {
 		System.gc();
 	}
 	
-	public String getConnectorOffset(int connectorType, String db, String name)
+	public String getConnectorOffset(int connectorType, String db, String name, String dstdb)
 	{
 		File inputFile = null;
 		Map<ByteBuffer, ByteBuffer> originalData = null;
@@ -944,19 +1070,19 @@ public class DebeziumRunner {
 		{
 			case TYPE_MYSQL:
 			{
-				inputFile = new File("pg_synchdb/mysql_" + name + "_offsets.dat");
+				inputFile = new File("pg_synchdb/mysql_" + name + "_" + dstdb + "_offsets.dat");
 				key = "[\"engine\",{\"server\":\"synchdb-connector\"}]";
 				break;
 			}
 			case TYPE_ORACLE:
 			{
-				inputFile = new File("pg_synchdb/oracle_" + name + "_offsets.dat");
+				inputFile = new File("pg_synchdb/oracle_" + name + "_" + dstdb + "_offsets.dat");
 				key = "[\"engine\",{\"server\":\"synchdb-connector\"}]";
 				break;
 			}
 			case TYPE_SQLSERVER:
 			{
-				inputFile = new File("pg_synchdb/sqlserver_" + name + "_offsets.dat");
+				inputFile = new File("pg_synchdb/sqlserver_" + name + "_" + dstdb + "_offsets.dat");
 				key = "[\"engine\",{\"server\":\"synchdb-connector\",\"database\":\"" + db + "\"}]";
 				break;
 			}

--- a/src/backend/executor/replication_agent.c
+++ b/src/backend/executor/replication_agent.c
@@ -943,7 +943,10 @@ ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** conne
 			"coalesce(data->>'jmx_exporter_conf', 'null'), "
 			"coalesce(data->>'olr_host', 'null'), "
 			"coalesce(data->>'olr_port', 'null'), "
-			"coalesce(data->>'olr_source', 'null') "
+			"coalesce(data->>'olr_source', 'null'), "
+			"coalesce(data->>'ispn_cache_type', 'null'), "
+			"coalesce(data->>'ispn_memory_type', 'null'), "
+			"coalesce(data->>'ispn_memory_size', 'null') "
 			"FROM "
 			"synchdb_conninfo WHERE name = '%s'",
 			SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, name);
@@ -989,6 +992,10 @@ ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** conne
 	conninfo->olr.olr_port = atoi(TextDatumGetCString(res[31]));
 	strlcpy(conninfo->olr.olr_source, TextDatumGetCString(res[32]), SYNCHDB_CONNINFO_NAME_SIZE);
 
+	strlcpy(conninfo->ispn.ispn_cache_type, TextDatumGetCString(res[33]), INFINISPAN_TYPE_SIZE);
+	strlcpy(conninfo->ispn.ispn_memory_type, TextDatumGetCString(res[34]), INFINISPAN_TYPE_SIZE);
+	conninfo->ispn.ispn_memory_size = atoi(TextDatumGetCString(res[35]));
+
 	elog(LOG, "name=%s hostname=%s, port=%d, user=%s pwd=%s srcdb=%s "
 			"dstdb=%s table=%s snapshottable=%s connector=%s extras(ssl_mode=%s ssl_keystore=%s "
 			"ssl_keystore_pass=%s ssl_truststore=%s ssl_truststore_pass=%s) "
@@ -996,7 +1003,9 @@ ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** conne
 			"jmx_auth=%s jmx_auth_passwdfile=%s jmx_auth_accessfile=%s jmx_ssl=%s "
 			"jmx_ssl_keystore=%s jmx_ssl_keystore_pass=%s jmx_ssl_truststore=%s "
 			"jmx_ssl_truststore_pass=%s jmx_exporter=%s jmx_exporter_port=%d "
-			"jmx_exporter_conf=%s olr_host=%s olr_port=%d olr_source=%s)",
+			"jmx_exporter_conf=%s)"
+			"olr(olr_host=%s olr_port=%d olr_source=%s)"
+			"ispn(ispn_cache_type='%s' ispn_memory_type='%s' ispn_memory_size=%u)",
 			conninfo->name, conninfo->hostname, conninfo->port,
 			conninfo->user, conninfo->pwd, conninfo->srcdb,
 			conninfo->dstdb, conninfo->table, conninfo->snapshottable, *connector,
@@ -1009,7 +1018,9 @@ ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** conne
 			conninfo->jmx.jmx_ssl_keystore_pass, conninfo->jmx.jmx_ssl_truststore,
 			conninfo->jmx.jmx_ssl_truststore_pass, conninfo->jmx.jmx_exporter,
 			conninfo->jmx.jmx_exporter_port, conninfo->jmx.jmx_exporter_conf,
-			conninfo->olr.olr_host, conninfo->olr.olr_port, conninfo->olr.olr_source);
+			conninfo->olr.olr_host, conninfo->olr.olr_port, conninfo->olr.olr_source,
+			conninfo->ispn.ispn_cache_type, conninfo->ispn.ispn_memory_type,
+			conninfo->ispn.ispn_memory_size);
 
 	MemoryContextDelete(conninfoContext);
 	return 0;

--- a/src/include/synchdb/synchdb.h
+++ b/src/include/synchdb/synchdb.h
@@ -61,6 +61,7 @@
 #define MAX_JAVA_OPTION_LENGTH 256
 #define SYNCHDB_OFFSET_FILE_PATTERN "pg_synchdb/%s_%s_%s_offsets.dat"
 #define SYNCHDB_SCHEMA_FILE_PATTERN "pg_synchdb/%s_%s_%s_schemahistory.dat"
+#define SYNCHDB_INFINISPAN_DIR "pg_synchdb/ispn_%s_%s"
 #define SYNCHDB_SECRET "930e62fb8c40086c23f543357a023c0c"
 #define SYNCHDB_CONNINFO_TABLE "synchdb_conninfo"
 #define SYNCHDB_ATTRIBUTE_TABLE "synchdb_attribute"

--- a/src/include/synchdb/synchdb.h
+++ b/src/include/synchdb/synchdb.h
@@ -45,6 +45,8 @@
 #define SYNCHDB_MAX_TZ_LEN 16
 #define SYNCHDB_MAX_TIMESTAMP_LEN 64
 
+#define INFINISPAN_TYPE_SIZE 32
+
 #define SYNCHDB_PG_MAJOR_VERSION  PG_VERSION_NUM / 100
 
 /*
@@ -255,6 +257,16 @@ typedef struct _OLRConnectionInfo
 } OLRConnectionInfo;
 
 /**
+ * Infinispan settings - alternative caching mechanism for oracle connector
+ */
+typedef struct _IspnInfo
+{
+	char ispn_cache_type[INFINISPAN_TYPE_SIZE];
+	char ispn_memory_type[INFINISPAN_TYPE_SIZE];
+	unsigned int ispn_memory_size;
+} IspnInfo;
+
+/**
  * ConnectionInfo - DBZ Connection info. These are put in shared memory so
  * connector background workers can access when they are spawned.
  */
@@ -275,6 +287,7 @@ typedef struct _ConnectionInfo
     ExtraConnectionInfo extra;
     JMXConnectionInfo jmx;
     OLRConnectionInfo olr;
+    IspnInfo ispn;
 } ConnectionInfo;
 
 /**

--- a/synchdb--1.0.sql
+++ b/synchdb--1.0.sql
@@ -140,3 +140,11 @@ LANGUAGE C IMMUTABLE STRICT;
 CREATE OR REPLACE FUNCTION synchdb_del_olr_conninfo(name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION synchdb_add_infinispan(name, name, int) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION synchdb_del_infinispan(name) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;


### PR DESCRIPTION
1) added infinispan support via synchdb_add_infinispan() and synchdb_del_infinispan()
2) fixed a problem where debezium print duplicate logs when connector is resumed from paused state
3) fixed a problem where offset file fails to load on connector startup