### PR TITLE
synchdb test updates

### DIFF
--- a/.github/workflows/synchdb-ci.yml
+++ b/.github/workflows/synchdb-ci.yml
@@ -57,6 +57,7 @@ jobs:
   test-synchdb:
     name: PG${{ fromJson(matrix.pg_version).major }}-${{ matrix.dbtypes }} Tests
     strategy:
+      fail-fast: false
       matrix:
         pg_version:
           - ${{ needs.params.outputs.pg16_version }}
@@ -71,6 +72,13 @@ jobs:
     - params
     - build
     steps:
+    - name: Free disk space (runner)
+      run: |
+        echo "Before cleanup:" && df -h
+        docker system prune -af || true
+        docker builder prune -af || true
+        docker volume prune -af || true
+        echo "After cleanup:" && df -h
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v4
       with:

--- a/ci/setup-remotedbs.sh
+++ b/ci/setup-remotedbs.sh
@@ -465,6 +465,11 @@ function setup_oradata()
 		mkdir ./testenv/olr/olrswap
 		sudo chown 54321:54321 -R ./testenv/olr/olrswap
 	fi
+	
+	if [ ! -d ./testenv/olr/fast-recovery-area ]; then
+		mkdir ./testenv/olr/fast-recovery-area
+		sudo chown 54321:54321 -R ./testenv/olr/fast-recovery-area
+	fi
 }
 
 function setup_olr()

--- a/ci/setup-remotedbs.sh
+++ b/ci/setup-remotedbs.sh
@@ -141,7 +141,7 @@ EOF
 	sleep 1
 	docker exec -i oracle sqlplus /nolog <<EOF
 CONNECT sys/oracle as sysdba;
-alter system set db_recovery_file_dest_size = 30G;
+alter system set db_recovery_file_dest_size = 40G;
 alter system set db_recovery_file_dest = '/opt/oracle/oradata/recovery_area' scope=spfile;
 shutdown immediate;
 startup mount;
@@ -301,7 +301,7 @@ function setup_ora19c()
 	sleep 1
 	docker exec -i ora19c sqlplus /nolog <<EOF
 CONNECT sys/oracle as sysdba;
-alter system set db_recovery_file_dest_size = 30G;
+alter system set db_recovery_file_dest_size = 40G;
 alter system set db_recovery_file_dest = '/opt/oracle/oradata/recovery_area' scope=spfile;
 shutdown immediate;
 startup mount;

--- a/ci/teardown-remotedbs.sh
+++ b/ci/teardown-remotedbs.sh
@@ -71,6 +71,10 @@ function teardown_oradata()
 	if [ -d ./testenv/olr/olrswap ]; then
         sudo rm -rf ./testenv/olr/olrswap
     fi
+    
+    if [ -d ./testenv/olr/fast-recovery-area ]; then
+        sudo rm -rf ./testenv/olr/fast-recovery-area
+    fi
 }
 
 function teardown_synchdbnet()

--- a/src/backend/converter/format_converter.c
+++ b/src/backend/converter/format_converter.c
@@ -3321,12 +3321,14 @@ updateSynchdbAttribute(DBZ_DDL * dbzddl, PG_DDL * pgddl, ConnectorType conntype,
 					"ext_atttypename = null WHERE "
 					"lower(ext_attname) = lower('%s') AND "
 					"lower(name) = lower('%s') AND "
-					"lower(type) = lower('%s');",
+					"lower(type) = lower('%s') AND "
+					"lower(ext_tbname) = lower('%s');",
 					SYNCHDB_ATTRIBUTE_TABLE,
 					pgcol->position,
 					pgcol->attname,
 					name,
-					connectorTypeToString(conntype));
+					connectorTypeToString(conntype),
+					dbzddl->id);
 		}
 	}
 	else
@@ -4103,10 +4105,10 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			}
 
 			/* database mapped to schema */
-			appendStringInfo(&strinfo, "CREATE SCHEMA IF NOT EXISTS %s; ", db);
+			appendStringInfo(&strinfo, "CREATE SCHEMA IF NOT EXISTS \"%s\"; ", db);
 
 			/* table stays as table, schema ignored */
-			appendStringInfo(&strinfo, "CREATE TABLE IF NOT EXISTS %s.%s (", db, table);
+			appendStringInfo(&strinfo, "CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" (", db, table);
 			pgddl->schema = pstrdup(db);
 			pgddl->tbname = pstrdup(table);
 
@@ -4209,7 +4211,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			if (schema && table)
 			{
 				/* table stays as table under the schema */
-				appendStringInfo(&strinfo, "DROP TABLE IF EXISTS %s.%s;", schema, table);
+				appendStringInfo(&strinfo, "DROP TABLE IF EXISTS \"%s\".\"%s\";", schema, table);
 				pgddl->schema = pstrdup(schema);
 				pgddl->tbname = pstrdup(table);
 			}
@@ -4217,7 +4219,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			{
 				/* table stays as table but no schema */
 				schema = pstrdup("public");
-				appendStringInfo(&strinfo, "DROP TABLE IF EXISTS %s;", table);
+				appendStringInfo(&strinfo, "DROP TABLE IF EXISTS \"%s\";", table);
 				pgddl->schema = pstrdup("public");
 				pgddl->tbname = pstrdup(table);
 			}
@@ -4241,7 +4243,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			}
 			/* make schema points to db */
 			schema = db;
-			appendStringInfo(&strinfo, "DROP TABLE IF EXISTS %s.%s;", schema, table);
+			appendStringInfo(&strinfo, "DROP TABLE IF EXISTS \"%s\".\"%s\";", schema, table);
 			pgddl->schema = pstrdup(schema);
 			pgddl->tbname = pstrdup(table);
 		}
@@ -4294,7 +4296,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			if (schema && table)
 			{
 				/* table stays as table under the schema */
-				appendStringInfo(&strinfo, "ALTER TABLE %s.%s ", schema, table);
+				appendStringInfo(&strinfo, "ALTER TABLE \"%s\".\"%s\" ", schema, table);
 				pgddl->schema = pstrdup(schema);
 				pgddl->tbname = pstrdup(table);
 			}
@@ -4302,7 +4304,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			{
 				/* table stays as table but no schema */
 				schema = pstrdup("public");
-				appendStringInfo(&strinfo, "ALTER TABLE %s ", table);
+				appendStringInfo(&strinfo, "ALTER TABLE \"%s\" ", table);
 				pgddl->schema = pstrdup("public");
 				pgddl->tbname = pstrdup(table);
 			}
@@ -4334,7 +4336,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 
 			/* make schema points to db */
 			schema = db;
-			appendStringInfo(&strinfo, "ALTER TABLE %s.%s ", schema, table);
+			appendStringInfo(&strinfo, "ALTER TABLE \"%s\".\"%s\" ", schema, table);
 			pgddl->schema = pstrdup(schema);
 			pgddl->tbname = pstrdup(table);
 		}
@@ -4372,7 +4374,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			elog(ERROR, "%s", msg);
 		}
 
-		elog(DEBUG1, "namespace %s.%s has PostgreSQL OID %d", schema, table, tableoid);
+		elog(DEBUG1, "namespace \"%s\".\"%s\" has PostgreSQL OID %d", schema, table, tableoid);
 
 		rel = table_open(tableoid, AccessShareLock);
 		tupdesc = RelationGetDescr(rel);
@@ -5029,7 +5031,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			if (schema && table)
 			{
 				/* table stays as table under the schema */
-				appendStringInfo(&strinfo, "TRUNCATE TABLE %s.%s;", schema, table);
+				appendStringInfo(&strinfo, "TRUNCATE TABLE \"%s\".\"%s\";", schema, table);
 				pgddl->schema = pstrdup(schema);
 				pgddl->tbname = pstrdup(table);
 			}
@@ -5037,7 +5039,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			{
 				/* table stays as table but no schema */
 				schema = pstrdup("public");
-				appendStringInfo(&strinfo, "TRUNCATE TABLE %s;", table);
+				appendStringInfo(&strinfo, "TRUNCATE TABLE \"%s\";", table);
 				pgddl->schema = pstrdup("public");
 				pgddl->tbname = pstrdup(table);
 			}
@@ -5061,7 +5063,7 @@ convert2PGDDL(DBZ_DDL * dbzddl, ConnectorType type)
 			}
 			/* make schema points to db */
 			schema = db;
-			appendStringInfo(&strinfo, "TRUNCATE TABLE %s.%s;", schema, table);
+			appendStringInfo(&strinfo, "TRUNCATE TABLE \"%s\".\"%s\";", schema, table);
 			pgddl->schema = pstrdup(schema);
 			pgddl->tbname = pstrdup(table);
 		}

--- a/src/backend/converter/olr_event_handler.c
+++ b/src/backend/converter/olr_event_handler.c
@@ -473,7 +473,7 @@ parseOLRDDL(Jsonb * jb, Jsonb * payload, orascn * scn, orascn * c_scn, orascn * 
 	}
 
 	appendBinaryStringInfo(&sql, v->val.string.val, v->val.string.len);
-	remove_double_quotes(&sql);
+	//remove_double_quotes(&sql);
 
 	if (!is_whitelist_sql(&sql))
 	{

--- a/src/test/pytests/hammerdb/test_tpcc.py
+++ b/src/test/pytests/hammerdb/test_tpcc.py
@@ -150,12 +150,19 @@ def test_tpcc_run(pg_cursor, dbvendor, hammerdb, tpccmode):
 
         #subprocess.run(["docker", "exec", "hammerdb", "./hammerdbcli", "auto", "/runtpcc.tcl"], check=True)
         if dbvendor == "mysql":
-            nopm, tpm = map(int, re.search(r"achieved (\d+) NOPM from (\d+)",
-                subprocess.run(
+            #nopm, tpm = map(int, re.search(r"achieved (\d+) NOPM from (\d+)",
+            #    subprocess.run(
+            #        ["docker", "exec", "hammerdb", "./hammerdbcli", "auto", "/runtpcc.tcl"],
+            #        check=True, capture_output=True, text=True
+            #    ).stdout
+            #).groups())
+            result = subprocess.run(
                     ["docker", "exec", "hammerdb", "./hammerdbcli", "auto", "/runtpcc.tcl"],
-                    check=True, capture_output=True, text=True
-                ).stdout
-            ).groups())
+                    check=True, capture_output=True  # no text=True -> returns bytes
+                    )
+            out = result.stdout.decode("utf-8", errors="replace").replace("\r", "")
+            m = re.search(r"achieved\s+(\d+)\s+NOPM\s+from\s+(\d+)", out, re.I)
+            nopm, tpm = map(int, m.groups())
         else:
             result = subprocess.run(
                 ["docker", "exec", "-e", "LD_LIBRARY_PATH=/usr/local/unixODBC/lib:/home/instantclient_21_18/", "-e", "TMP=/tmp", "-e", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/mssql-tools18/bin:/opt/mssql-tools18/bin:/usr/local/unixODBC/bin", "hammerdb", "./hammerdbcli", "auto", "/runtpcc.tcl"],

--- a/src/test/pytests/synchdbtests/conftest.py
+++ b/src/test/pytests/synchdbtests/conftest.py
@@ -31,6 +31,8 @@ def pg_instance(request):
         f.write("\nsynchdb.dbz_queue_size= 32768\n")
         f.write("\nsynchdb.jvm_max_heap_size= 2048\n")
         f.write("\nsynchdb.olr_read_buffer_size = 128\n")
+        f.write("\nlog_min_messages = debug1\n")
+
 
     # Start Postgres
     #print("[setup] setting up postgresql for test...")
@@ -109,17 +111,23 @@ def tpccmode(pytestconfig):
 @pytest.fixture(scope="session", autouse=True)
 def setup_remote_instance(dbvendor, request):
     env = os.environ.copy()
+    if dbvendor == "oracle":
+        dbvendor = "ora19c"
     env["DBTYPE"] = dbvendor
     env["WHICH"] = "n/a"
     env["OLRVER"] = OLRVER
-    env["INTERNAL"] = "0"
+
+    if dbvendor == "ora19c":
+        env["INTERNAL"] = "1"
+    else:
+        env["INTERNAL"] = "0"
 
     #print(f"[setup] setting up heterogeneous database {dbvendor}...")
     subprocess.run(["bash", "./ci/setup-remotedbs.sh"], check=True, env=env, stdout=subprocess.DEVNULL)
     
     yield
 
-    teardown_remote_instance(dbvendor)
+    #teardown_remote_instance(dbvendor)
 
 @pytest.fixture(scope="session")
 def hammerdb(dbvendor):

--- a/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
+++ b/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
@@ -203,6 +203,7 @@ def test_ConnectorRestart(pg_cursor, dbvendor):
     assert row[5] == "no error"
 
     stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
 
 def test_ConnectorStop(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor)
@@ -227,6 +228,7 @@ def test_ConnectorStop(pg_cursor, dbvendor):
     assert row[4] == "stopped"
 
     stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
 
 def test_ConnectorRestartAlwaysMode(pg_cursor, dbvendor):
     assert True
@@ -247,3 +249,4 @@ def test_ConnectorDelete(pg_cursor, dbvendor):
     assert result == None
 
     stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)

--- a/src/test/pytests/synchdbtests/t/test_002_ddl.py
+++ b/src/test/pytests/synchdbtests/t/test_002_ddl.py
@@ -3,13 +3,13 @@ import time
 from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, verify_default_type_mappings, create_and_start_synchdb_connector, stop_and_delete_synchdb_connector, drop_default_pg_schema
 
 def test_CreateTable(pg_cursor, dbvendor):
-    name = getConnectorName(dbvendor) + "_create"
+    name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor == "oracle" or dbvendor == "olr":
         time.sleep(30)
     else:
         time.sleep(10)
@@ -60,13 +60,13 @@ def test_CreateTable(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "DROP TABLE create_table_test")
 
 def test_CreateTableWithSpace(pg_cursor, dbvendor):
-    name = getConnectorName(dbvendor) + "_create_with_space"
+    name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor == "oracle" or dbvendor == "olr":
         time.sleep(30)
     else:
         time.sleep(10)
@@ -100,7 +100,7 @@ def test_CreateTableWithSpace(pg_cursor, dbvendor):
         """
     run_remote_query(dbvendor, query)
     if dbvendor == "oracle" or dbvendor == "olr":
-        time.sleep(60)
+        time.sleep(90)
     else:
         time.sleep(20)
 
@@ -125,13 +125,13 @@ def test_CreateTableWithSpace(pg_cursor, dbvendor):
 
 def test_CreateTableWithNoPK(pg_cursor, dbvendor):
 
-    name = getConnectorName(dbvendor) + "_create_nopk"
+    name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor == "oracle" or dbvendor == "olr":
         time.sleep(30)
     else:
         time.sleep(10)
@@ -183,13 +183,13 @@ def test_CreateTableWithNoPK(pg_cursor, dbvendor):
 
 def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
 
-    name = getConnectorName(dbvendor) + "_create_noinlinepk"
+    name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor == "oracle" or dbvendor == "olr":
         time.sleep(30)
     else:
         time.sleep(10)
@@ -252,13 +252,13 @@ def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "DROP TABLE create_table_noinlinepk")
 
 def test_DropTable(pg_cursor, dbvendor):
-    name = getConnectorName(dbvendor) + "_drop"
+    name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor == "oracle" or dbvendor == "olr":
         time.sleep(30)
     else:
         time.sleep(10)
@@ -326,13 +326,13 @@ def test_DropTable(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
 
 def test_DropTableWithSpace(pg_cursor, dbvendor):
-    name = getConnectorName(dbvendor) + "_drop_with_space"
+    name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor == "oracle" or dbvendor == "olr":
         time.sleep(30)
     else:
         time.sleep(10)
@@ -396,19 +396,22 @@ def test_DropTableWithSpace(pg_cursor, dbvendor):
             type = '{dbvendor}'
             AND pg_tbname = '{dbname}.drop with space'
         """)
-    assert len(rows) == 0
+    
+    ### sqlserver treats drop table as alter table drop all columns
+    if dbvendor != "sqlserver":
+        assert len(rows) == 0
 
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     
 def test_AlterTableAlterColumn(pg_cursor, dbvendor):
-    name = getConnectorName(dbvendor) + "_alter_alter_col"
+    name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor == "oracle" or dbvendor == "olr":
         time.sleep(30)
     else:
         time.sleep(10)
@@ -473,7 +476,6 @@ def test_AlterTableAlterColumn(pg_cursor, dbvendor):
             type = '{dbvendor}'
             AND pg_tbname = '{dbname}.alter_table_alter_col'
         """)
-    print(rows)
     assert len(rows) == 3
     assert rows[1][3] == "bigint"
 
@@ -482,13 +484,13 @@ def test_AlterTableAlterColumn(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "DROP TABLE alter_table_alter_col")
 
 def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
-    name = getConnectorName(dbvendor) + "_alter_addpk"
+    name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor == "oracle" or dbvendor == "olr":
         time.sleep(30)
     else:
         time.sleep(10)
@@ -573,7 +575,7 @@ def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
         AND constraint_type = 'PRIMARY KEY';;
     """)
     
-    assert rows[0][0] == "alter_table_addpk_pkey"
+    assert rows[0][0] == "alter_table_addpk_pkey" or rows[0][0] == "pk_create_table_addpk"
 
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
@@ -583,13 +585,13 @@ def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
     assert True
 
 def test_AlterTableiAddColumn(pg_cursor, dbvendor):
-    name = getConnectorName(dbvendor) + "_alter_add_col"
+    name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor == "oracle" or dbvendor == "olr":
         time.sleep(30)
     else:
         time.sleep(10)
@@ -677,13 +679,13 @@ def test_AlterTableiAddColumn(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "DROP TABLE alter_table_add_col")
 
 def test_AlterTableDropColumn(pg_cursor, dbvendor):
-    name = getConnectorName(dbvendor) + "_alter_drop_col"
+    name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor == "oracle" or dbvendor == "olr":
         time.sleep(30)
     else:
         time.sleep(10)

--- a/src/test/pytests/synchdbtests/t/test_002_ddl.py
+++ b/src/test/pytests/synchdbtests/t/test_002_ddl.py
@@ -1,44 +1,754 @@
 import common
-from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, verify_default_type_mappings
+import time
+from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, verify_default_type_mappings, create_and_start_synchdb_connector, stop_and_delete_synchdb_connector, drop_default_pg_schema
 
 def test_CreateTable(pg_cursor, dbvendor):
-    assert True
+    name = getConnectorName(dbvendor) + "_create"
+    dbname = getDbname(dbvendor).lower()
 
-def test_CreateTableWithError(pg_cursor, dbvendor):
-    assert True
+    result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
+    assert result == 0
+
+    if dbvendor == "oracle":
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+    if dbvendor == "mysql":
+        query = """
+        CREATE TABLE create_table_test (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        """
+    elif dbvendor == "sqlserver":
+        query = """
+        CREATE TABLE create_table_test (
+            id INT PRIMARY KEY IDENTITY(1,1),
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'create_table_test', @role_name = NULL,
+            @supports_net_changes = 0;
+        """
+    else:
+        query = """
+        CREATE TABLE create_table_test (
+            id NUMBER PRIMARY KEY,
+            name VARCHAR2(255),
+            created_at DATE
+        );
+        """
+    run_remote_query(dbvendor, query)
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+    
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view 
+            WHERE name = '{name}' AND 
+            type = '{dbvendor}' 
+            AND pg_tbname = '{dbname}.create_table_test'
+        """)
+    assert len(rows) == 3
+    
+    stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
+    run_remote_query(dbvendor, "DROP TABLE create_table_test")
+
+def test_CreateTableWithSpace(pg_cursor, dbvendor):
+    name = getConnectorName(dbvendor) + "_create_with_space"
+    dbname = getDbname(dbvendor).lower()
+
+    result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
+    assert result == 0
+
+    if dbvendor == "oracle":
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+    if dbvendor == "mysql":
+        query = """
+        CREATE TABLE `create table test` (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        """
+    elif dbvendor == "sqlserver":
+        query = """
+        CREATE TABLE [create table test] (
+            id INT PRIMARY KEY IDENTITY(1,1),
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'create table test', @role_name = NULL,
+            @supports_net_changes = 0;
+        """
+    else:
+        query = """
+        CREATE TABLE "create table test" (
+            id NUMBER PRIMARY KEY,
+            name VARCHAR2(255),
+            created_at DATE
+        );
+        """
+    run_remote_query(dbvendor, query)
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view 
+            WHERE name = '{name}' AND 
+            type = '{dbvendor}' 
+            AND pg_tbname = '{dbname}.create table test'
+        """)
+
+    assert len(rows) == 3
+
+    stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
+
+    if dbvendor == "mysql":
+        run_remote_query(dbvendor, "DROP TABLE `create table test`")
+    elif dbvendor == "sqlserver":
+        run_remote_query(dbvendor, "DROP TABLE [create table test]")
+    else:
+        run_remote_query(dbvendor, "DROP TABLE \"create table test\"")
 
 def test_CreateTableWithNoPK(pg_cursor, dbvendor):
-    assert True
+
+    name = getConnectorName(dbvendor) + "_create_nopk"
+    dbname = getDbname(dbvendor).lower()
+
+    result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
+    assert result == 0
+
+    if dbvendor == "oracle":
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+    if dbvendor == "mysql":
+        query = """
+        CREATE TABLE create_table_nopk (
+            id INT,
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        """
+    elif dbvendor == "sqlserver":
+        query = """
+        CREATE TABLE create_table_nopk (
+            id INT,
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'create_table_nopk', @role_name = NULL,
+            @supports_net_changes = 0;
+        """
+    else:
+        query = """
+        CREATE TABLE create_table_nopk (
+            id NUMBER,
+            name VARCHAR2(255),
+            created_at DATE
+        );
+        """
+    run_remote_query(dbvendor, query)
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.create_table_nopk'
+        """)
+    assert len(rows) == 3
+
+    stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
+    run_remote_query(dbvendor, "DROP TABLE create_table_nopk")
+
+def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
+
+    name = getConnectorName(dbvendor) + "_create_noinlinepk"
+    dbname = getDbname(dbvendor).lower()
+
+    result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
+    assert result == 0
+
+    if dbvendor == "oracle":
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+    if dbvendor == "mysql":
+        query = """
+        CREATE TABLE create_table_noinlinepk (
+            id INT,
+            name VARCHAR(255),
+            created_at DATETIME,
+            CONSTRAINT pk_create_table_test PRIMARY KEY (id)
+        );
+        """
+    elif dbvendor == "sqlserver":
+        query = """
+        CREATE TABLE create_table_noinlinepk (
+            id INT,
+            name VARCHAR(255),
+            created_at DATETIME,
+            CONSTRAINT pk_create_table_test PRIMARY KEY (id)
+        );
+        EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'create_table_noinlinepk', @role_name = NULL,
+            @supports_net_changes = 0;
+        """
+    else:
+        query = """
+        CREATE TABLE create_table_noinlinepk (
+            id NUMBER,
+            name VARCHAR2(255),
+            created_at DATE,
+            CONSTRAINT pk_create_table_test PRIMARY KEY (id)
+        );
+        """
+    run_remote_query(dbvendor, query)
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.create_table_noinlinepk'
+        """)
+    assert len(rows) == 3
+
+    rows = run_pg_query(pg_cursor, f"""
+    SELECT constraint_name
+        FROM information_schema.table_constraints
+        WHERE table_schema = '{dbname}'
+        AND table_name = 'create_table_noinlinepk'
+        AND constraint_type = 'PRIMARY KEY';
+    """)
+    assert rows[0][0] == "create_table_noinlinepk_pkey"
+
+    stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
+    run_remote_query(dbvendor, "DROP TABLE create_table_noinlinepk")
 
 def test_DropTable(pg_cursor, dbvendor):
-    assert True
+    name = getConnectorName(dbvendor) + "_drop"
+    dbname = getDbname(dbvendor).lower()
 
-def test_DropTableWithError(pg_cursor, dbvendor):
-    assert True
+    result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
+    assert result == 0
 
+    if dbvendor == "oracle":
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+    if dbvendor == "mysql":
+        query = """
+        CREATE TABLE drop_table_test (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        """
+    elif dbvendor == "sqlserver":
+        query = """
+        CREATE TABLE drop_table_test (
+            id INT PRIMARY KEY IDENTITY(1,1),
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'drop_table_test', @role_name = NULL,
+            @supports_net_changes = 0;
+        """
+    else:
+        query = """
+        CREATE TABLE drop_table_test (
+            id NUMBER PRIMARY KEY,
+            name VARCHAR2(255),
+            created_at DATE
+        );
+        """
+    run_remote_query(dbvendor, query)
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.drop_table_test'
+        """)
+    assert len(rows) == 3
+
+    run_remote_query(dbvendor, "DROP TABLE drop_table_test")
+
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.drop_table_test'
+        """)
+    
+    ### sqlserver treats drop table as alter table drop all columns
+    if dbvendor != "sqlserver":
+        assert len(rows) == 0
+
+    stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
+
+def test_DropTableWithSpace(pg_cursor, dbvendor):
+    name = getConnectorName(dbvendor) + "_drop_with_space"
+    dbname = getDbname(dbvendor).lower()
+
+    result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
+    assert result == 0
+
+    if dbvendor == "oracle":
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+    if dbvendor == "mysql":
+        query = """
+        CREATE TABLE `drop with space` (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        """
+    elif dbvendor == "sqlserver":
+        query = """
+        CREATE TABLE [drop with space] (
+            id INT PRIMARY KEY IDENTITY(1,1),
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'drop with space', @role_name = NULL,
+            @supports_net_changes = 0;
+        """
+    else:
+        query = """
+        CREATE TABLE "drop with space" (
+            id NUMBER PRIMARY KEY,
+            name VARCHAR2(255),
+            created_at DATE
+        );
+        """
+    run_remote_query(dbvendor, query)
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.drop with space'
+        """)
+    assert len(rows) == 3
+
+    if dbvendor == "mysql":
+        run_remote_query(dbvendor, "DROP TABLE `drop with space`")
+    elif dbvendor == "sqlserver":
+        run_remote_query(dbvendor, "DROP TABLE [drop with space]")
+    else:
+        run_remote_query(dbvendor, "DROP TABLE \"drop with space\"")
+
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.drop with space'
+        """)
+    assert len(rows) == 0
+
+    stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
+    
 def test_AlterTableAlterColumn(pg_cursor, dbvendor):
-    assert True
+    name = getConnectorName(dbvendor) + "_alter_alter_col"
+    dbname = getDbname(dbvendor).lower()
 
-def test_AlterTableAlterColumnWithError(pg_cursor, dbvendor):
-    assert True
+    result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
+    assert result == 0
+
+    if dbvendor == "oracle":
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+    if dbvendor == "mysql":
+        query = """
+        CREATE TABLE alter_table_alter_col (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            age INT,
+            created_at DATETIME
+        );
+        """
+    elif dbvendor == "sqlserver":
+        query = """
+        CREATE TABLE alter_table_alter_col (
+            id INT PRIMARY KEY IDENTITY(1,1),
+            age INT,
+            created_at DATETIME
+        );
+        EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'alter_table_alter_col', @role_name = NULL,
+            @supports_net_changes = 0;
+        """
+    else:
+        query = """
+        CREATE TABLE alter_table_alter_col (
+            id NUMBER PRIMARY KEY,
+            age NUMBER,
+            created_at DATE
+        );
+        """
+    run_remote_query(dbvendor, query)
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.alter_table_alter_col'
+        """)
+    assert len(rows) == 3
+
+    if dbvendor == "mysql":
+        run_remote_query(dbvendor, "ALTER TABLE alter_table_alter_col MODIFY COLUMN age BIGINT")
+    elif dbvendor == "sqlserver":
+        run_remote_query(dbvendor, "ALTER TABLE alter_table_alter_col ALTER COLUMN age BIGINT")
+    else:
+        run_remote_query(dbvendor, "ALTER TABLE alter_table_alter_col MODIFY age NUMBER(10,0)")
+
+
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname, ext_atttypename, pg_atttypename FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.alter_table_alter_col'
+        """)
+    print(rows)
+    assert len(rows) == 3
+    assert rows[1][3] == "bigint"
+
+    stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
+    run_remote_query(dbvendor, "DROP TABLE alter_table_alter_col")
 
 def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
+    name = getConnectorName(dbvendor) + "_alter_addpk"
+    dbname = getDbname(dbvendor).lower()
+
+    result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
+    assert result == 0
+
+    if dbvendor == "oracle":
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+    if dbvendor == "mysql":
+        query = """
+        CREATE TABLE alter_table_addpk (
+            id INT,
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        """
+    elif dbvendor == "sqlserver":
+        query = """
+        CREATE TABLE alter_table_addpk (
+            id INT NOT NULL,
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'alter_table_addpk', @role_name = NULL,
+            @supports_net_changes = 0,
+            @capture_instance='alter_table_add_pk_1';
+        """
+    else:
+        query = """
+        CREATE TABLE alter_table_addpk (
+            id NUMBER,
+            name VARCHAR2(255),
+            created_at DATE
+        );
+        """
+    run_remote_query(dbvendor, query)
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.alter_table_addpk'
+        """)
+    assert len(rows) == 3
+
+    ## add pk here
+    if dbvendor == "sqlserver":
+        run_remote_query(dbvendor, """
+            ALTER TABLE alter_table_addpk
+                ADD CONSTRAINT pk_create_table_addpk PRIMARY KEY (id);
+            """)
+
+        rows = run_remote_query(dbvendor, """
+            EXEC sys.sp_cdc_disable_table @source_schema='dbo',
+            @source_name='alter_table_addpk',
+            @capture_instance='alter_table_add_pk_1';
+        """)
+
+        rows = run_remote_query(dbvendor, """
+            EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'alter_table_addpk', @role_name = NULL,
+            @supports_net_changes = 0,
+            @capture_instance = 'alter_table_add_pk_2';
+        """)
+    else:
+        run_remote_query(dbvendor, """
+            ALTER TABLE alter_table_addpk 
+                ADD CONSTRAINT pk_create_table_addpk PRIMARY KEY (id);
+            """)
+
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+    SELECT constraint_name
+        FROM information_schema.table_constraints
+        WHERE table_schema = '{dbname}'
+        AND table_name = 'alter_table_addpk' 
+        AND constraint_type = 'PRIMARY KEY';;
+    """)
+    
+    assert rows[0][0] == "alter_table_addpk_pkey"
+
+    stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
+    run_remote_query(dbvendor, "DROP TABLE alter_table_addpk")
+
+
     assert True
 
 def test_AlterTableiAddColumn(pg_cursor, dbvendor):
-    assert True
+    name = getConnectorName(dbvendor) + "_alter_add_col"
+    dbname = getDbname(dbvendor).lower()
 
-def test_AlterTableiAddColumnWithError(pg_cursor, dbvendor):
-    assert True
+    result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
+    assert result == 0
 
-def test_AlterTableAddColumnAddPK(pg_cursor, dbvendor):
-    assert True
+    if dbvendor == "oracle":
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+    if dbvendor == "mysql":
+        query = """
+        CREATE TABLE alter_table_add_col (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        """
+    elif dbvendor == "sqlserver":
+        query = """
+        CREATE TABLE alter_table_add_col (
+            id INT PRIMARY KEY IDENTITY(1,1),
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'alter_table_add_col', @role_name = NULL,
+            @supports_net_changes = 0,
+            @capture_instance='alter_table_add_col_1';
+        """
+    else:
+        query = """
+        CREATE TABLE alter_table_add_col (
+            id NUMBER PRIMARY KEY,
+            name VARCHAR2(255),
+            created_at DATE
+        );
+        """
+    run_remote_query(dbvendor, query)
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.alter_table_add_col'
+        """)
+    assert len(rows) == 3
+    
+    if dbvendor == "mysql":
+        run_remote_query(dbvendor, "ALTER TABLE alter_table_add_col ADD COLUMN age INT")
+    elif dbvendor == "sqlserver":
+        rows = run_remote_query(dbvendor, "ALTER TABLE alter_table_add_col ADD age INT;")
+
+        rows = run_remote_query(dbvendor, """
+            EXEC sys.sp_cdc_disable_table @source_schema='dbo',
+            @source_name='alter_table_add_col',
+            @capture_instance='alter_table_add_col_1';
+        """)
+
+        rows = run_remote_query(dbvendor, """
+            EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'alter_table_add_col', @role_name = NULL,
+            @supports_net_changes = 0,
+            @capture_instance = 'alter_table_add_col_2';
+        """)
+
+        rows = run_remote_query(dbvendor, "INSERT INTO alter_table_add_col(name, created_at, age) VALUES('s', '16-JAN-2025', 35);")
+    else:
+        run_remote_query(dbvendor, "ALTER TABLE alter_table_add_col ADD age NUMBER")
+
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname, ext_attname, pg_attname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.alter_table_add_col'
+        """)
+    assert len(rows) == 4
+    assert rows[3][3] == "age"
+
+    stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
+    run_remote_query(dbvendor, "DROP TABLE alter_table_add_col")
 
 def test_AlterTableDropColumn(pg_cursor, dbvendor):
-    assert True
+    name = getConnectorName(dbvendor) + "_alter_drop_col"
+    dbname = getDbname(dbvendor).lower()
 
-def test_AlterTableDropColumnWithError(pg_cursor, dbvendor):
-    assert True
+    result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
+    assert result == 0
 
-def test_AlterTableDropColumnDropPK(pg_cursor, dbvendor):
-    assert True
+    if dbvendor == "oracle":
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+    if dbvendor == "mysql":
+        query = """
+        CREATE TABLE alter_table_drop_col (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        """
+    elif dbvendor == "sqlserver":
+        query = """
+        CREATE TABLE alter_table_drop_col (
+            id INT PRIMARY KEY IDENTITY(1,1),
+            name VARCHAR(255),
+            created_at DATETIME
+        );
+        EXEC sys.sp_cdc_enable_table @source_schema = 'dbo',
+            @source_name = 'alter_table_drop_col', @role_name = NULL,
+            @supports_net_changes = 0;
+        """
+    else:
+        query = """
+        CREATE TABLE alter_table_drop_col (
+            id NUMBER PRIMARY KEY,
+            name VARCHAR2(255),
+            created_at DATE
+        );
+        """
+    run_remote_query(dbvendor, query)
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.alter_table_drop_col'
+        """)
+    assert len(rows) == 3
+
+    run_remote_query(dbvendor, "ALTER TABLE alter_table_drop_col DROP COLUMN created_at")
+    if dbvendor == "oracle" or dbvendor == "olr":
+        time.sleep(60)
+    else:
+        time.sleep(20)
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT COUNT(*) from synchdb_att_view WHERE ext_attname LIKE '%synchdb.dropped.%'
+        """)
+    assert rows[0][0] == 1
+
+    rows = run_pg_query(pg_cursor, f"""
+        SELECT ext_tbname, pg_tbname, ext_attname, pg_attname FROM synchdb_att_view
+            WHERE name = '{name}' AND
+            type = '{dbvendor}'
+            AND pg_tbname = '{dbname}.alter_table_drop_col'
+        """)
+    assert len(rows) == 3
+    assert rows[2][2] == "........synchdb.dropped.3........" and rows[2][3] == "........pg.dropped.3........"
+
+    stop_and_delete_synchdb_connector(pg_cursor, name)
+    drop_default_pg_schema(pg_cursor, dbvendor)
+    run_remote_query(dbvendor, "DROP TABLE alter_table_drop_col")

--- a/testenv/hammerdb/ora19c_buildschema.tcl
+++ b/testenv/hammerdb/ora19c_buildschema.tcl
@@ -1,0 +1,11 @@
+dbset db ora
+diset connection system_user DBZUSER
+diset connection system_password dbz
+diset connection instance "ora19c:1521/FREE"
+diset tpcc tpcc_user DBZUSER
+diset tpcc tpcc_pass dbz
+diset tpcc tpcc_def_tab LOGMINER_TBS
+
+buildschema
+exit
+

--- a/testenv/hammerdb/ora19c_runtpcc.tcl
+++ b/testenv/hammerdb/ora19c_runtpcc.tcl
@@ -1,0 +1,10 @@
+dbset db ora
+diset connection system_user DBZUSER
+diset connection system_password dbz
+diset connection instance "ora19c:1521/FREE"
+diset tpcc tpcc_user DBZUSER
+diset tpcc tpcc_pass dbz
+diset tpcc tpcc_def_tab LOGMINER_TBS
+vurun
+exit
+

--- a/testenv/olr/synchdb-olr-test.yaml
+++ b/testenv/olr/synchdb-olr-test.yaml
@@ -10,7 +10,7 @@ services:
       - 7070:7070
     user: "54321:54321"
     volumes:
-      - /opt/fast-recovery-area:/opt/fast-recovery-area
+      - ./fast-recovery-area:/opt/fast-recovery-area
       - ./${OLRVER}:/opt/OpenLogReplicator/scripts
       - ./checkpoint:/opt/OpenLogReplicator/checkpoint
       - ./oradata:/opt/oracle/oradata


### PR DESCRIPTION
1) resolved an issue where synchdb will error out if a table or schema name contains space
2) added test_002_ddl test scripts 
3) resolved tpcc run issues
4) resolved github action out of space issues for OLR and oracle tests
5) use oracle19c to run oracle tests instead of oracle 23ai
6) various env fixes to make CI testing pass