### PR TITLE
fix potential memory issue

### DIFF
--- a/src/backend/executor/replication_agent.c
+++ b/src/backend/executor/replication_agent.c
@@ -435,10 +435,19 @@ synchdb_handle_insert(List * colval, Oid tableoid, ConnectorType type, int natts
 
 		if (synchdb_error_strategy == STRAT_SKIP_ON_ERROR)
 		{
-			ExecCloseIndices(resultRelInfo);
-			table_close(rel, AccessShareLock);
-			ExecResetTupleTable(estate->es_tupleTable, false);
-			FreeExecutorState(estate);
+			if(resultRelInfo)
+			{
+				ExecCloseIndices(resultRelInfo);
+			}
+			if(rel)
+			{
+				table_close(rel, AccessShareLock);
+			}
+			if(estate)
+			{
+				ExecResetTupleTable(estate->es_tupleTable, false);
+				FreeExecutorState(estate);
+			}
 			FlushErrorState();
 			return -1;
 		}
@@ -628,11 +637,20 @@ synchdb_handle_update(List * colvalbefore, List * colvalafter, Oid tableoid, Con
 
 		if (synchdb_error_strategy == STRAT_SKIP_ON_ERROR)
 		{
-			ExecCloseIndices(resultRelInfo);
+			if(resultRelInfo)
+			{
+				ExecCloseIndices(resultRelInfo);
+			}
 			EvalPlanQualEnd(&epqstate);
-			ExecResetTupleTable(estate->es_tupleTable, false);
-			FreeExecutorState(estate);
-			table_close(rel, AccessShareLock);
+			if(estate)
+			{
+				ExecResetTupleTable(estate->es_tupleTable, false);
+				FreeExecutorState(estate);
+			}
+			if(rel)
+			{
+				table_close(rel, AccessShareLock);
+			}
 			FlushErrorState();
 			return -1;
 		}

--- a/src/backend/olr/olr_client.c
+++ b/src/backend/olr/olr_client.c
@@ -113,6 +113,7 @@ olr_client_start_or_cont_replication(char * source, bool which)
 		if (response)
 		{
 			retcode = response->code;
+			open_log_replicator__pb__redo_response__free_unpacked(response, NULL);
 			return retcode;
 		}
 		else

--- a/src/backend/synchdb/synchdb.c
+++ b/src/backend/synchdb/synchdb.c
@@ -1457,8 +1457,8 @@ prepare_bgw(BackgroundWorker *worker, const ConnectionInfo *connInfo, const char
 	snprintf(worker->bgw_type, BGW_MAXLEN, "synchdb engine: %s", connector);
 
 	/* append destination database to worker->bgw_name for clarity */
-	strcat(worker->bgw_name, " -> ");
-	strcat(worker->bgw_name, connInfo->dstdb);
+	strlcat(worker->bgw_name, " -> ", BGW_MAXLEN);
+	strlcat(worker->bgw_name, connInfo->dstdb, BGW_MAXLEN);
 
 	/* [ivorysql] check if we are running under ivorysql's oracle compatible mode */
 	val = GetConfigOption("ivorysql.compatible_mode", true, false);
@@ -3500,7 +3500,7 @@ olr_set_offset_from_raw(char * offsetdata)
 	}
 	if (c_idx_pos)
 	{
-		sscanf(c_scn_pos, "\"c_idx\":%llu", &c_idx);
+		sscanf(c_idx_pos, "\"c_idx\":%llu", &c_idx);
 	}
 	else
 	{


### PR DESCRIPTION
Summary of Fixes:

1. Prevent crashes (`src/backend/executor/replication_agent.c`):
    * `synchdb_handle_insert(...)` and `synchdb_handle_update(...)` check for NULL before release memory just like `synchdb_handle_insert(...)`

2. Release protoc memory (`src/backend/olr/olr_client.c`):
    * if `response` is created successfully by `open_log_replicator__pb__redo_response__unpack`, then call corresponding `open_log_replicator__pb__redo_response__free_unpacked` to relese it.
 
3. Fixes (`src/backend/synchdb/synchdb.c`):
    * use safe function `strlcat`
    * scans into wrong varable