### PR TITLE
added Debezium and oracle_fdw CDB/PDB support tests: oracle23aicheck

### DIFF
--- a/.github/workflows/synchdb-ci.yml
+++ b/.github/workflows/synchdb-ci.yml
@@ -88,7 +88,6 @@ jobs:
         dbtypes:
           - mysql
           - oracle
-          - oracle23ai
           - sqlserver
           - olr
           - postgres

--- a/.github/workflows/synchdb-ci.yml
+++ b/.github/workflows/synchdb-ci.yml
@@ -88,6 +88,7 @@ jobs:
         dbtypes:
           - mysql
           - oracle
+          - oracle23ai
           - sqlserver
           - olr
           - postgres

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ install_oracle_parser:
 	@echo "installing against pgmajor ${PG_MAJOR}"
 	make install -C src/backend/olr/oracle_parser${PG_MAJOR}
 
-.PHONY: dbcheck mysqlcheck sqlservercheck oraclecheck dbcheck-tpcc mysqlcheck-tpcc sqlservercheck-tpcc oraclecheck-tpcc
+.PHONY: dbcheck mysqlcheck sqlservercheck oraclecheck oracle23aicheck dbcheck-tpcc mysqlcheck-tpcc sqlservercheck-tpcc oraclecheck-tpcc
 dbcheck:
 	@command -v pytest >/dev/null 2>&1 || { echo >&2 "❌ pytest not found in PATH."; exit 1; }
 	@command -v docker >/dev/null 2>&1 || { echo >&2 "❌ docker not found in PATH."; exit 1; }
@@ -163,6 +163,9 @@ sqlservercheck:
 
 oraclecheck:
 	$(MAKE) dbcheck DB=oracle
+
+oracle23aicheck:
+	$(MAKE) dbcheck DB=oracle23ai
 
 olrcheck:
 	$(MAKE) dbcheck DB=olr

--- a/ci/setup-remotedbs.sh
+++ b/ci/setup-remotedbs.sh
@@ -91,6 +91,187 @@ function setup_sqlserver()
 	exit 0
 }
 
+function setup_oracle23ai(){
+	needsetup=0
+	CONTAINER_NAME="eztest_oracle23ai"
+
+	set +e
+	echo "setting up ${CONTAINER_NAME}..."
+	if ! docker ps -a --format '{{.Names}}' | grep -q ${CONTAINER_NAME}; then
+        # container has not run before. Run a new one
+		if [ $INTERNAL -eq 1 ]; then
+        	docker_compose -f testenv/oracle/synchdb-oracle23ai-test-internal.yaml up -d
+		else
+			docker_compose -f testenv/oracle/synchdb-oracle23ai-test.yaml up -d
+		fi
+		wait_for_container_ready ${CONTAINER_NAME} "DATABASE IS READY TO USE"
+        needsetup=1
+    else
+		state=$(docker inspect -f '{{.State.Status}}' ${CONTAINER_NAME} 2>/dev/null || echo unknown)
+		if [ $state == "running" ]; then
+            echo "${CONTAINER_NAME} is already running..."
+        elif [ $state == "exited" ]; then
+            echo "${CONTAINER_NAME} exited, starting it again..."
+            docker start ${CONTAINER_NAME} >/dev/null 2>&1
+			wait_for_container_ready ${CONTAINER_NAME} "DATABASE IS READY TO USE"
+        else
+            echo "${CONTAINER_NAME} in unknown state. Remove it and try again..."
+        fi
+		return
+    fi
+
+	if [ $needsetup -ne 1 ]; then
+        echo "skip setting up ${CONTAINER_NAME}, assuming it done..."
+		return
+    fi
+    set -e
+
+	# check if oracle has been initialized
+	isinit=$(docker exec ${CONTAINER_NAME} sh -c '[ -d /opt/oracle/oradata/recovery_area ]' && echo exists || echo missing)
+	if [ "$isinit" == "exists" ]; then
+		echo "${CONTAINER_NAME} has been setup already. Skip setup..."
+		return
+	fi
+	docker exec -i ${CONTAINER_NAME} mkdir /opt/oracle/oradata/recovery_area
+	docker exec -i ${CONTAINER_NAME} sqlplus / as sysdba <<EOF
+Alter user sys identified by oracle;
+exit;
+EOF
+	sleep 1
+	docker exec -i ${CONTAINER_NAME} sqlplus /nolog <<EOF
+CONNECT sys/oracle as sysdba;
+alter system set db_recovery_file_dest_size = 40G;
+alter system set db_recovery_file_dest = '/opt/oracle/oradata/recovery_area' scope=spfile;
+shutdown immediate;
+startup mount;
+alter database archivelog;
+alter database open;
+archive log list;
+exit;
+EOF
+	sleep 1
+	docker exec -i ${CONTAINER_NAME} sqlplus sys/oracle@//localhost:1521/FREE as sysdba <<EOF
+ALTER DATABASE ADD SUPPLEMENTAL LOG DATA;
+ALTER PROFILE DEFAULT LIMIT FAILED_LOGIN_ATTEMPTS UNLIMITED;
+exit;
+EOF
+	docker exec -i ${CONTAINER_NAME} sqlplus sys/oracle@//localhost:1521/FREE as sysdba <<EOF
+CREATE TABLESPACE LOGMINER_TBS DATAFILE '/opt/oracle/oradata/FREE/logminer_tbs.dbf' SIZE 25M REUSE AUTOEXTEND ON MAXSIZE UNLIMITED;
+exit;
+EOF
+	docker exec -i ${CONTAINER_NAME} sqlplus sys/oracle@//localhost:1521/FREEPDB1 as sysdba <<EOF
+CREATE TABLESPACE LOGMINER_TBS DATAFILE '/opt/oracle/oradata/FREE/FREEPDB1/logminer_tbs.dbf' SIZE 25M REUSE AUTOEXTEND ON MAXSIZE UNLIMITED;
+exit;
+EOF
+	docker exec -i ${CONTAINER_NAME} sqlplus sys/oracle@//localhost:1521/FREE as sysdba <<'EOF'
+CREATE USER c##dbzuser IDENTIFIED BY dbz DEFAULT TABLESPACE LOGMINER_TBS QUOTA UNLIMITED ON LOGMINER_TBS CONTAINER=ALL;
+GRANT CREATE SESSION TO c##dbzuser CONTAINER=ALL;
+GRANT SET CONTAINER TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$DATABASE TO c##dbzuser CONTAINER=ALL;
+GRANT FLASHBACK ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT_CATALOG_ROLE TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE_CATALOG_ROLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY TRANSACTION TO c##dbzuser CONTAINER=ALL;
+GRANT LOGMINING TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY DICTIONARY TO c##dbzuser CONTAINER=ALL;
+GRANT CREATE TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT LOCK ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT CREATE SEQUENCE TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE ON DBMS_LOGMNR TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE ON DBMS_LOGMNR_D TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOG TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOG_HISTORY TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_LOGS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_CONTENTS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_PARAMETERS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGFILE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$ARCHIVED_LOG TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$ARCHIVE_DEST_STATUS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$TRANSACTION TO c##dbzuser CONTAINER=ALL; 
+GRANT SELECT ON V_$MYSTAT TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$STATNAME TO c##dbzuser CONTAINER=ALL; 
+GRANT EXECUTE ON DBMS_WORKLOAD_REPOSITORY TO C##DBZUSER;
+GRANT SELECT ON DBA_HIST_SNAPSHOT TO C##DBZUSER;
+GRANT EXECUTE ON DBMS_WORKLOAD_REPOSITORY TO PUBLIC;
+ALTER DATABASE ADD LOGFILE GROUP 4 ('/opt/oracle/oradata/FREE/redo04.log') SIZE 512M;
+ALTER DATABASE ADD LOGFILE GROUP 5 ('/opt/oracle/oradata/FREE/redo05.log') SIZE 512M;
+ALTER DATABASE ADD LOGFILE GROUP 6 ('/opt/oracle/oradata/FREE/redo06.log') SIZE 512M;
+GRANT CONNECT, RESOURCE TO C##DBZUSER;
+GRANT CREATE SESSION TO C##DBZUSER;
+GRANT CREATE TABLE TO C##DBZUSER;
+GRANT CREATE VIEW TO C##DBZUSER;
+GRANT CREATE PROCEDURE TO C##DBZUSER;
+GRANT CREATE SEQUENCE TO C##DBZUSER;
+GRANT CREATE TRIGGER TO C##DBZUSER;
+GRANT CREATE ANY INDEX TO C##DBZUSER;
+GRANT CREATE ANY TABLE TO C##DBZUSER;
+GRANT CREATE ANY PROCEDURE TO C##DBZUSER;
+GRANT ALTER ANY TABLE TO C##DBZUSER;
+GRANT EXECUTE ANY PROCEDURE TO C##DBZUSER;
+GRANT DROP ANY TABLE TO C##DBZUSER;
+GRANT DROP ANY INDEX TO C##DBZUSER;
+GRANT DROP ANY SEQUENCE TO C##DBZUSER;
+GRANT DROP ANY PROCEDURE TO C##DBZUSER;
+GRANT DROP ANY VIEW TO C##DBZUSER;
+GRANT DROP ANY TRIGGER TO C##DBZUSER;
+GRANT DROP ANY SYNONYM TO C##DBZUSER;
+GRANT DROP ANY MATERIALIZED VIEW TO C##DBZUSER;
+exit;
+EOF
+
+	# setup FREEPDB1
+	docker exec -i ${CONTAINER_NAME} sqlplus sys/oracle@//localhost:1521/FREEPDB1 as sysdba <<'EOF'
+ALTER DATABASE ADD SUPPLEMENTAL LOG DATA;
+ALTER PROFILE DEFAULT LIMIT FAILED_LOGIN_ATTEMPTS UNLIMITED;
+CREATE USER DBZUSER IDENTIFIED BY dbz
+DEFAULT TABLESPACE USERS
+TEMPORARY TABLESPACE TEMP;
+GRANT CREATE SESSION          TO DBZUSER;
+GRANT SELECT ANY TABLE        TO DBZUSER;
+GRANT SELECT ANY TRANSACTION  TO DBZUSER;
+GRANT SELECT_CATALOG_ROLE     TO DBZUSER;
+GRANT EXECUTE_CATALOG_ROLE    TO DBZUSER;
+GRANT FLASHBACK ANY TABLE     TO DBZUSER;
+GRANT LOGMINING               TO DBZUSER;
+GRANT LOCK ANY TABLE          TO DBZUSER;
+GRANT SELECT ON V_$DATABASE          TO DBZUSER;
+GRANT SELECT ON V_$LOG               TO DBZUSER;
+GRANT SELECT ON V_$LOGFILE           TO DBZUSER;
+GRANT SELECT ON V_$ARCHIVED_LOG      TO DBZUSER;
+GRANT SELECT ON V_$ARCHIVE_DEST      TO DBZUSER;
+GRANT SELECT ON V_$TRANSACTION       TO DBZUSER;
+GRANT SELECT ON V_$INSTANCE          TO DBZUSER;
+GRANT SELECT ON V_$LOG_HISTORY       TO DBZUSER;
+GRANT SELECT ON V_$PARAMETER         TO DBZUSER;
+GRANT CREATE TABLE TO DBZUSER;
+ALTER USER DBZUSER QUOTA UNLIMITED ON USERS;
+exit;
+EOF
+	docker exec -i ${CONTAINER_NAME} sqlplus 'DBZUSER/dbz@//localhost:1521/FREEPDB1' <<EOF
+CREATE TABLE orders (
+order_number NUMBER PRIMARY KEY,
+order_date DATE,
+purchaser NUMBER,
+quantity NUMBER,
+product_id NUMBER);
+commit;
+ALTER TABLE orders ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
+exit;
+EOF
+
+	docker exec -i ${CONTAINER_NAME} sqlplus 'DBZUSER/dbz@//localhost:1521/FREEPDB1' <<EOF
+INSERT INTO orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10001, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
+INSERT INTO orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10002, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
+INSERT INTO orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10003, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
+INSERT INTO orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10004, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
+commit;
+exit;
+EOF
+
+	exit 0
+}
+
 function setup_oracle()
 {
 	needsetup=0
@@ -239,55 +420,6 @@ INSERT INTO orders(order_number, order_date, purchaser, quantity, product_id) VA
 INSERT INTO orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10002, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
 INSERT INTO orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10003, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
 INSERT INTO orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10004, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
-commit;
-exit;
-EOF
-
-	# setup FREEPDB1
-	docker exec -i oracle sqlplus sys/oracle@//localhost:1521/FREEPDB1 as sysdba <<'EOF'
-ALTER DATABASE ADD SUPPLEMENTAL LOG DATA;
-ALTER PROFILE DEFAULT LIMIT FAILED_LOGIN_ATTEMPTS UNLIMITED;
-CREATE USER DBZUSER IDENTIFIED BY your_password
-DEFAULT TABLESPACE USERS
-TEMPORARY TABLESPACE TEMP;
-GRANT CREATE SESSION          TO DBZUSER;
-GRANT SELECT ANY TABLE        TO DBZUSER;
-GRANT SELECT ANY TRANSACTION  TO DBZUSER;
-GRANT SELECT_CATALOG_ROLE     TO DBZUSER;
-GRANT EXECUTE_CATALOG_ROLE    TO DBZUSER;
-GRANT FLASHBACK ANY TABLE     TO DBZUSER;
-GRANT LOGMINING               TO DBZUSER;
-GRANT LOCK ANY TABLE          TO DBZUSER;
-GRANT SELECT ON V_$DATABASE          TO DBZUSER;
-GRANT SELECT ON V_$LOG               TO DBZUSER;
-GRANT SELECT ON V_$LOGFILE           TO DBZUSER;
-GRANT SELECT ON V_$ARCHIVED_LOG      TO DBZUSER;
-GRANT SELECT ON V_$ARCHIVE_DEST      TO DBZUSER;
-GRANT SELECT ON V_$TRANSACTION       TO DBZUSER;
-GRANT SELECT ON V_$INSTANCE          TO DBZUSER;
-GRANT SELECT ON V_$LOG_HISTORY       TO DBZUSER;
-GRANT SELECT ON V_$PARAMETER         TO DBZUSER;
-GRANT CREATE TABLE TO DBZUSER;
-ALTER USER DBZUSER QUOTA UNLIMITED ON USERS;
-exit;
-EOF
-	docker exec -i oracle sqlplus 'DBZUSER/your_password@//localhost:1521/FREEPDB1' <<EOF
-CREATE TABLE pdb_orders (
-order_number NUMBER PRIMARY KEY,
-order_date DATE,
-purchaser NUMBER,
-quantity NUMBER,
-product_id NUMBER);
-commit;
-ALTER TABLE pdb_orders ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
-exit;
-EOF
-
-	docker exec -i oracle sqlplus 'DBZUSER/your_password@//localhost:1521/FREEPDB1' <<EOF
-INSERT INTO pdb_orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10001, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
-INSERT INTO pdb_orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10002, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
-INSERT INTO pdb_orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10003, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
-INSERT INTO pdb_orders(order_number, order_date, purchaser, quantity, product_id) VALUES (10004, TO_DATE('2024-01-01', 'YYYY-MM-DD'), 1003, 2, 107);
 commit;
 exit;
 EOF
@@ -589,6 +721,9 @@ function setup_remotedb()
 			;;
 		"oracle")
 			setup_oracle
+			;;
+		"oracle23ai")
+			setup_oracle23ai
 			;;
 		"ora19c")
 			setup_ora19c "notolr"

--- a/ci/setup-remotedbs.sh
+++ b/ci/setup-remotedbs.sh
@@ -140,6 +140,19 @@ EOF
 	sleep 1
 	docker exec -i ${CONTAINER_NAME} sqlplus /nolog <<EOF
 CONNECT sys/oracle as sysdba;
+ALTER DATABASE ADD LOGFILE GROUP 4 ('/opt/oracle/oradata/redo04.log') SIZE 512M;
+ALTER DATABASE ADD LOGFILE GROUP 5 ('/opt/oracle/oradata/redo05.log') SIZE 512M;
+ALTER DATABASE ADD LOGFILE GROUP 6 ('/opt/oracle/oradata/redo06.log') SIZE 512M;
+ALTER SYSTEM SWITCH LOGFILE;
+ALTER SYSTEM SWITCH LOGFILE;
+ALTER SYSTEM SWITCH LOGFILE;
+ALTER SYSTEM CHECKPOINT;
+ALTER DATABASE DROP LOGFILE GROUP 1;
+ALTER DATABASE DROP LOGFILE GROUP 2;
+ALTER DATABASE DROP LOGFILE GROUP 3;
+ALTER DATABASE ADD LOGFILE GROUP 1 ('/opt/oracle/oradata/redo01.log') SIZE 512M;
+ALTER DATABASE ADD LOGFILE GROUP 2 ('/opt/oracle/oradata/redo02.log') SIZE 512M;
+ALTER DATABASE ADD LOGFILE GROUP 3 ('/opt/oracle/oradata/redo03.log') SIZE 512M;
 alter system set db_recovery_file_dest_size = 40G;
 alter system set db_recovery_file_dest = '/opt/oracle/oradata/recovery_area' scope=spfile;
 shutdown immediate;

--- a/ci/teardown-remotedbs.sh
+++ b/ci/teardown-remotedbs.sh
@@ -35,6 +35,14 @@ function teardown_oracle()
 	#docker-compose -f testenv/oracle/synchdb-oracle-test.yaml down
 }
 
+function teardown_oracle23ai()
+{
+	CONTAINER_NAME="eztest_oracle23ai"
+	echo "tearing down ${CONTAINER_NAME}..."
+	docker stop ${CONTAINER_NAME} >/dev/null 2>&1
+	docker rm ${CONTAINER_NAME} >/dev/null 2>&1
+}
+
 function teardown_ora19c()
 {
 	echo "tearing down ora19c..."
@@ -103,6 +111,9 @@ function teardown_remotedb()
 			;;
 		"oracle")
 			teardown_oracle
+			;;
+		"oracle23ai")
+			teardown_oracle23ai
 			;;
 		"ora19c")
 			teardown_ora19c

--- a/src/test/pytests/synchdbtests/common.py
+++ b/src/test/pytests/synchdbtests/common.py
@@ -422,6 +422,7 @@ def drop_repslot_and_pub(dbvendor, name, dstdb):
 
 def restart_remote_db(dbvendor, wait_time=30):
     """
+    TODO: Upgrade Debezium, and remove this workaround.
     BUG WORKAROUND: Restart the remote database container.
 
     Restart the remote database container.

--- a/src/test/pytests/synchdbtests/common.py
+++ b/src/test/pytests/synchdbtests/common.py
@@ -120,14 +120,14 @@ def getSchema(dbvendor):
         return ORA19C_SCHEMA
 
 def run_pg_query(cursor, query):
-    print(f"[{datetime.now().strftime('%H:%M:%S')}][run_pg_query] {query}")  # Debug: print the query being executed
+    # print(f"[{datetime.now().strftime('%H:%M:%S')}][run_pg_query] {query}")  # Debug: print the query being executed
     cursor.execute(query)
     if cursor.description:  # Only fetch if query returns results
         return cursor.fetchall()
     return None
 
 def run_pg_query_one(cursor, query):
-    print(f"[{datetime.now().strftime('%H:%M:%S')}][run_pg_query_one] {query}")  # Debug: print the query being executed
+    # print(f"[{datetime.now().strftime('%H:%M:%S')}][run_pg_query_one] {query}")  # Debug: print the query being executed
     cursor.execute(query)
     if cursor.description:
         return cursor.fetchone()
@@ -224,7 +224,7 @@ def run_remote_query(where, query, srcdb=None):
         "postgres": POSTGRES_DB
     }[where]
 
-    print(f"[{datetime.now().strftime('%H:%M:%S')}][run_remote_query] Running on {db}: {query}")  # Debug: print the query being executed
+    # print(f"[{datetime.now().strftime('%H:%M:%S')}][run_remote_query] Running on {db}: {query}")  # Debug: print the query being executed
 
     try:
         if where == "mysql":

--- a/src/test/pytests/synchdbtests/common.py
+++ b/src/test/pytests/synchdbtests/common.py
@@ -56,6 +56,16 @@ ORA19C_PASS="dbz"
 ORA19C_DB="FREE"
 ORA19C_SCHEMA="DBZUSER"
 
+ORACLE23AI_HOST=get_container_ip(name="eztest_oracle23ai")
+ORACLE23AI_PORT=1521
+ORACLE23AI_USER="DBZUSER"
+ORACLE23AI_PASS="dbz"
+ORACLE23AI_DB="FREEPDB1"
+ORACLE23AI_SCHEMA="DBZUSER"
+ORACLE23AI_CDB="FREE"
+ORACLE23AI_COMMON_USER="c##dbzuser"
+ORACLE23AI_COMMON_PASS="dbz"
+
 OLR_HOST=get_container_ip(name="OpenLogReplicator")
 OLR_PORT="7070"
 OLR_SERVICE="ORACLE"
@@ -72,7 +82,7 @@ def getConnectorName(dbvendor):
         return "mysqlconn"
     elif dbvendor == "sqlserver":
         return "sqlserverconn"
-    elif dbvendor == "oracle":
+    elif dbvendor in ("oracle", "oracle23ai"):
         return "oracleconn"
     elif dbvendor == "postgres":
         return "postgresconn"
@@ -86,6 +96,8 @@ def getDbname(dbvendor):
         return SQLSERVER_DB
     elif dbvendor == "oracle":
         return ORACLE_DB
+    elif dbvendor == "oracle23ai":
+        return ORACLE23AI_DB
     elif dbvendor == "postgres":
         return POSTGRES_DB
     else:
@@ -99,18 +111,22 @@ def getSchema(dbvendor):
         return SQLSERVER_SCHEMA
     elif dbvendor == "oracle":
         return ORACLE_SCHEMA
+    elif dbvendor == "oracle23ai":
+        return ORACLE23AI_SCHEMA
     elif dbvendor == "postgres":
         return POSTGRES_SCHEMA
     else:
         return ORA19C_SCHEMA
 
 def run_pg_query(cursor, query):
+    # print(f"[run_pg_query] {query}")  # Debug: print the query being executed
     cursor.execute(query)
     if cursor.description:  # Only fetch if query returns results
         return cursor.fetchall()
     return None
 
 def run_pg_query_one(cursor, query):
+    # print(f"[run_pg_query_one] {query}")  # Debug: print the query being executed
     cursor.execute(query)
     if cursor.description:
         return cursor.fetchone()
@@ -202,6 +218,7 @@ def run_remote_query(where, query, srcdb=None):
         "mysql": MYSQL_DB,
         "sqlserver": SQLSERVER_DB,
         "oracle": ORACLE_DB,
+        "oracle23ai": ORACLE23AI_DB,
         "olr": ORA19C_DB,
         "postgres": POSTGRES_DB
     }[where]
@@ -244,6 +261,8 @@ def run_remote_query(where, query, srcdb=None):
             """
             if where == "oracle":
                 result = subprocess.check_output(["docker", "exec", "-i", "ora19c", "sqlplus", "-S", f"{ORACLE_USER}/{ORACLE_PASS}@//{ORACLE_HOST}:{ORACLE_PORT}/{db}"], input=sql, text=True).strip()
+            elif where == "oracle23ai":
+                result = subprocess.check_output(["docker", "exec", "-i", "eztest_oracle23ai", "sqlplus", "-S", f"{ORACLE23AI_USER}/{ORACLE23AI_PASS}@//{ORACLE23AI_HOST}:{ORACLE23AI_PORT}/{db}"], input=sql, text=True).strip()
             else:
                 global ORA19C_HOST
                 max_tries = 20
@@ -279,6 +298,7 @@ def create_synchdb_connector(cursor, vendor, name, srcdb=None, srcschema=None):
         "mysql": MYSQL_DB,
         "sqlserver": SQLSERVER_DB,
         "oracle": ORACLE_DB,
+        "oracle23ai": ORACLE23AI_DB,
         "olr": ORA19C_DB,
         "postgres": POSTGRES_DB
     }[vendor]
@@ -287,6 +307,7 @@ def create_synchdb_connector(cursor, vendor, name, srcdb=None, srcschema=None):
         "mysql": "null",
         "sqlserver": SQLSERVER_SCHEMA,
         "oracle": ORACLE_SCHEMA,
+        "oracle23ai": ORACLE23AI_SCHEMA,
         "olr": ORA19C_SCHEMA,
         "postgres": POSTGRES_SCHEMA
     }[vendor]
@@ -307,8 +328,20 @@ def create_synchdb_connector(cursor, vendor, name, srcdb=None, srcschema=None):
             tries += 1
             time.sleep(1)
 
-        assert ORACLE_HOST != None
+        assert ORACLE_HOST is not None
         result = run_pg_query_one(cursor, f"SELECT synchdb_add_conninfo('{name}','{ORACLE_HOST}', {ORACLE_PORT}, '{ORACLE_USER}', '{ORACLE_PASS}', '{db}', '{schema}', 'null', 'null', 'oracle');")
+    elif vendor == "oracle23ai":
+        global ORACLE23AI_HOST
+        max_tries = 20
+        tries = 0
+
+        while ORACLE23AI_HOST is None and tries < max_tries:
+            ORACLE23AI_HOST = get_container_ip(name="eztest_oracle23ai")
+            tries += 1
+            time.sleep(1)
+
+        assert ORACLE23AI_HOST is not None
+        result = run_pg_query_one(cursor, f"SELECT synchdb_add_conninfo('{name}','{ORACLE23AI_HOST}', {ORACLE23AI_PORT}, '{ORACLE23AI_COMMON_USER}', '{ORACLE23AI_COMMON_PASS}', '{ORACLE23AI_CDB}/{db}', '{schema}', 'null', 'null', 'oracle');")
     elif vendor == "postgres":
         result = run_pg_query_one(cursor, f"SELECT synchdb_add_conninfo('{name}','{POSTGRES_HOST}', {POSTGRES_PORT}, '{POSTGRES_USER}', '{POSTGRES_PASS}', '{db}', '{schema}', 'null', 'null', 'postgres');")
 
@@ -356,6 +389,9 @@ def drop_default_pg_schema(cursor, vendor):
     elif vendor == "postgres":
         row = run_pg_query_one(cursor, f"DROP SCHEMA IF EXISTS postgres CASCADE")
         row = run_pg_query_one(cursor, f"DROP SCHEMA IF EXISTS \"POSTGRES\" CASCADE")
+    elif vendor == "oracle23ai":
+        row = run_pg_query_one(cursor, f"DROP SCHEMA IF EXISTS freepdb1 CASCADE")
+        row = run_pg_query_one(cursor, f"DROP SCHEMA IF EXISTS \"FREEPDB1\" CASCADE")
     else:
         row = run_pg_query_one(cursor, f"DROP SCHEMA IF EXISTS free CASCADE")
         row = run_pg_query_one(cursor, f"DROP SCHEMA IF EXISTS \"FREE\" CASCADE")

--- a/src/test/pytests/synchdbtests/common.py
+++ b/src/test/pytests/synchdbtests/common.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import socket
 import time
+from datetime import datetime
 
 def get_container_ip(name: str, network: str = "synchdbnet") -> str | None:
     # Go template with the specific network:
@@ -119,14 +120,14 @@ def getSchema(dbvendor):
         return ORA19C_SCHEMA
 
 def run_pg_query(cursor, query):
-    # print(f"[run_pg_query] {query}")  # Debug: print the query being executed
+    print(f"[{datetime.now().strftime('%H:%M:%S')}][run_pg_query] {query}")  # Debug: print the query being executed
     cursor.execute(query)
     if cursor.description:  # Only fetch if query returns results
         return cursor.fetchall()
     return None
 
 def run_pg_query_one(cursor, query):
-    # print(f"[run_pg_query_one] {query}")  # Debug: print the query being executed
+    print(f"[{datetime.now().strftime('%H:%M:%S')}][run_pg_query_one] {query}")  # Debug: print the query being executed
     cursor.execute(query)
     if cursor.description:
         return cursor.fetchone()
@@ -222,6 +223,8 @@ def run_remote_query(where, query, srcdb=None):
         "olr": ORA19C_DB,
         "postgres": POSTGRES_DB
     }[where]
+
+    print(f"[{datetime.now().strftime('%H:%M:%S')}][run_remote_query] Running on {db}: {query}")  # Debug: print the query being executed
 
     try:
         if where == "mysql":
@@ -415,3 +418,31 @@ def drop_repslot_and_pub(dbvendor, name, dstdb):
 
     run_remote_query(dbvendor, f"SELECT pg_drop_replication_slot('{name}_{dstdb}_synchdb_slot')")
     run_remote_query(dbvendor, f"DROP PUBLICATION IF EXISTS {name}_{dstdb}_synchdb_pub")
+
+
+def restart_remote_db(dbvendor, wait_time=30):
+    """
+    BUG WORKAROUND: Restart the remote database container.
+
+    Restart the remote database container.
+    This is mainly used for oracle23ai, because it seems
+    to have some stability issue after running for a while,
+    and restart can help recover it.
+    """
+    if dbvendor == "mysql":
+        subprocess.run(["docker", "restart", "mysql"], check=True)
+    elif dbvendor == "sqlserver":
+        subprocess.run(["docker", "restart", "sqlserver"], check=True)
+    elif dbvendor == "oracle":
+        subprocess.run(["docker", "restart", "ora19c"], check=True)
+    elif dbvendor == "oracle23ai":
+        subprocess.run(["docker", "restart", "eztest_oracle23ai"], check=True)
+    elif dbvendor == "olr":
+        subprocess.run(["docker", "restart", "OpenLogReplicator"], check=True)
+    else:
+        print(f"restart not supported for {dbvendor}")
+        return
+
+    if wait_time > 0:
+        print(f"waiting {wait_time} seconds for {dbvendor} to restart...")
+        time.sleep(wait_time)

--- a/src/test/pytests/synchdbtests/conftest.py
+++ b/src/test/pytests/synchdbtests/conftest.py
@@ -16,8 +16,6 @@ def pg_instance(request):
     temp_dir = "synchdb_testdir"
     data_dir = os.path.join(temp_dir, "data")
     log_file = os.path.join(temp_dir, "logfile")
-
-    subprocess.run(["pg_ctl", "-D", data_dir, "stop", "-m", "immediate"], check=False, stdout=subprocess.DEVNULL)
     
     # remove dir if exists
     if os.path.isdir(temp_dir):
@@ -70,7 +68,7 @@ def pg_instance(request):
     # do not remove postgresql server dir if failed
     if request.session.testsfailed > 0:
         print(f"test failed: postgresql server dir and log retained at {data_dir} and {log_file}")
-        # subprocess.run(["pg_ctl", "-D", data_dir, "stop", "-m", "immediate"], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["pg_ctl", "-D", data_dir, "stop", "-m", "immediate"], check=True, stdout=subprocess.DEVNULL)
     else:
         subprocess.run(["pg_ctl", "-D", data_dir, "stop", "-m", "immediate"], check=True, stdout=subprocess.DEVNULL)
         shutil.rmtree(temp_dir)
@@ -126,7 +124,7 @@ def setup_remote_instance(dbvendor, request):
     else:
         env["INTERNAL"] = "0"
 
-    print(f"[setup] setting up heterogeneous database {dbvendor}...")
+    #print(f"[setup] setting up heterogeneous database {dbvendor}...")
     subprocess.run(["bash", "./ci/setup-remotedbs.sh"], check=True, env=env, stdout=subprocess.DEVNULL)
     
     yield

--- a/src/test/pytests/synchdbtests/conftest.py
+++ b/src/test/pytests/synchdbtests/conftest.py
@@ -119,12 +119,12 @@ def setup_remote_instance(dbvendor, request):
     env["WHICH"] = "n/a"
     env["OLRVER"] = OLRVER
 
-    if dbvendor == "ora19c":
+    if dbvendor in ("ora19c", "oracle23ai"):
         env["INTERNAL"] = "1"
     else:
         env["INTERNAL"] = "0"
 
-    #print(f"[setup] setting up heterogeneous database {dbvendor}...")
+    print(f"[setup] setting up heterogeneous database {dbvendor}...")
     subprocess.run(["bash", "./ci/setup-remotedbs.sh"], check=True, env=env, stdout=subprocess.DEVNULL)
     
     yield

--- a/src/test/pytests/synchdbtests/conftest.py
+++ b/src/test/pytests/synchdbtests/conftest.py
@@ -16,6 +16,8 @@ def pg_instance(request):
     temp_dir = "synchdb_testdir"
     data_dir = os.path.join(temp_dir, "data")
     log_file = os.path.join(temp_dir, "logfile")
+
+    subprocess.run(["pg_ctl", "-D", data_dir, "stop", "-m", "immediate"], check=False, stdout=subprocess.DEVNULL)
     
     # remove dir if exists
     if os.path.isdir(temp_dir):
@@ -68,7 +70,7 @@ def pg_instance(request):
     # do not remove postgresql server dir if failed
     if request.session.testsfailed > 0:
         print(f"test failed: postgresql server dir and log retained at {data_dir} and {log_file}")
-        subprocess.run(["pg_ctl", "-D", data_dir, "stop", "-m", "immediate"], check=True, stdout=subprocess.DEVNULL)
+        # subprocess.run(["pg_ctl", "-D", data_dir, "stop", "-m", "immediate"], check=True, stdout=subprocess.DEVNULL)
     else:
         subprocess.run(["pg_ctl", "-D", data_dir, "stop", "-m", "immediate"], check=True, stdout=subprocess.DEVNULL)
         shutil.rmtree(temp_dir)

--- a/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
+++ b/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
@@ -1435,8 +1435,10 @@ def test_ConnectorStartNodataModeFDW(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "no_data")
     assert result == 0
 
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(30)
+    elif dbvendor == "oracle23ai":
+        time.sleep(60)
     else:
         time.sleep(10)
 

--- a/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
+++ b/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
@@ -432,8 +432,10 @@ def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(50)
+    elif dbvendor == "oracle23ai":
+        time.sleep(80)
     else:
         time.sleep(10)
 

--- a/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
+++ b/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
@@ -3,6 +3,10 @@ import time
 from datetime import datetime
 from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, verify_default_type_mappings, stop_and_delete_synchdb_connector, drop_default_pg_schema, create_and_start_synchdb_connector, update_guc_conf, getSchema, drop_repslot_and_pub
 
+# import pytest
+# pytestmark = pytest.mark.skip(reason="跳过此文件")
+
+
 def test_ConnectorCreate(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor)
     result = create_synchdb_connector(pg_cursor, dbvendor, name)
@@ -11,7 +15,10 @@ def test_ConnectorCreate(pg_cursor, dbvendor):
     result = run_pg_query_one(pg_cursor, f"SELECT name, isactive, data->>'connector' FROM synchdb_conninfo WHERE name = '{name}'")
     assert result[0] == name
     assert result[1] == False
-    assert result[2] == dbvendor
+    if dbvendor in ('oracle', 'oracle23ai'):
+        assert result[2] == 'oracle'
+    else:
+        assert result[2] == dbvendor
 
     result = run_pg_query_one(pg_cursor, f"SELECT synchdb_add_extra_conninfo('{name}', 'verify_ca', '/path/ks', 'kspass', '/path/ts/', 'tspass')")
     assert result[0] == 0
@@ -22,6 +29,7 @@ def test_ConnectorCreate(pg_cursor, dbvendor):
     assert result[3] == "/path/ts/"
 
     stop_and_delete_synchdb_connector(pg_cursor, name)
+
 
 def test_CreateExtraConninfo(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor)
@@ -38,6 +46,7 @@ def test_CreateExtraConninfo(pg_cursor, dbvendor):
     assert row[2] == "truststore"
 
     stop_and_delete_synchdb_connector(pg_cursor, name)
+
 
 def test_RemoveExtraConninfo(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor)
@@ -58,6 +67,7 @@ def test_RemoveExtraConninfo(pg_cursor, dbvendor):
 
     stop_and_delete_synchdb_connector(pg_cursor, name)
 
+
 def test_ConnectorStart(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor)
     dbname = getDbname(dbvendor).lower()
@@ -72,14 +82,17 @@ def test_ConnectorStart(pg_cursor, dbvendor):
     assert row[0] == 0
 
     # oracle takes longer to start initial snapshot
-    if dbvendor == "oracle":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(20)
     else:
         time.sleep(10)
 
     row = run_pg_query_one(pg_cursor, f"SELECT name, connector_type, pid, stage, state, err FROM synchdb_state_view WHERE name = '{name}'")
     assert row[0] == name
-    assert row[1] == dbvendor
+    if dbvendor in ('oracle', 'oracle23ai'):
+        assert row[1] == 'oracle'
+    else:
+        assert row[1] == dbvendor
     assert row[2] > -1
     assert row[3] == "initial snapshot" or row[3] == "change data capture"
     assert row[4] == "polling"
@@ -90,6 +103,7 @@ def test_ConnectorStart(pg_cursor, dbvendor):
 
     if dbvendor == "postgres":
         update_guc_conf(pg_cursor, "synchdb.snapshot_engine", "'debezium'", True)
+
 
 def test_InitialSnapshotDBZ(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbzsnap"
@@ -104,7 +118,7 @@ def test_InitialSnapshotDBZ(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -128,7 +142,10 @@ def test_InitialSnapshotDBZ(pg_cursor, dbvendor):
 
     if dbvendor != "postgres":
         # check table name mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             id = row[0].split(".")
@@ -137,13 +154,19 @@ def test_InitialSnapshotDBZ(pg_cursor, dbvendor):
             else:
                 assert row[0].lower() == row[1]
         # check attname mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert row[0].lower() == row[1]
 
         # check data type mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
@@ -152,7 +175,7 @@ def test_InitialSnapshotDBZ(pg_cursor, dbvendor):
     pgrow = run_pg_query_one(pg_cursor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM {dbname}.orders WHERE order_number = 10003")
     extrow = run_remote_query(dbvendor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM orders WHERE order_number = 10003")
     assert int(pgrow[0]) == int(extrow[0][0])
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%d-%b-%y')
     elif dbvendor == "postgres":
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%Y-%m-%d %H:%M:%S')
@@ -165,6 +188,7 @@ def test_InitialSnapshotDBZ(pg_cursor, dbvendor):
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
+
 
 def test_InitialSnapshotFDW(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_fdwsnap"
@@ -198,7 +222,7 @@ def test_InitialSnapshotFDW(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -221,7 +245,10 @@ def test_InitialSnapshotFDW(pg_cursor, dbvendor):
     assert int(pgrowcount[0]) == int(extrowcount[0][0])
 
     # check table name mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         id = row[0].split(".")
@@ -231,13 +258,19 @@ def test_InitialSnapshotFDW(pg_cursor, dbvendor):
             assert row[0].lower() == row[1]
 
     # check attname mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert row[0].lower() == row[1]
 
     # check data type mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
@@ -246,7 +279,7 @@ def test_InitialSnapshotFDW(pg_cursor, dbvendor):
     pgrow = run_pg_query_one(pg_cursor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM {dbname}.orders WHERE order_number = 10003")
     extrow = run_remote_query(dbvendor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM orders WHERE order_number = 10003")
     assert int(pgrow[0]) == int(extrow[0][0])
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%d-%b-%y')
     elif dbvendor == "postgres":
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%Y-%m-%d %H:%M:%S')
@@ -270,8 +303,8 @@ def test_InitialSnapshotFDW(pg_cursor, dbvendor):
         """
     
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
-        time.sleep(30)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(50)
     else:
         time.sleep(10)
 
@@ -285,6 +318,7 @@ def test_InitialSnapshotFDW(pg_cursor, dbvendor):
     update_guc_conf(pg_cursor, "synchdb.snapshot_engine", "'debezium'", True)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     time.sleep(10)
+
 
 def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbzsnap_upper"
@@ -301,7 +335,7 @@ def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -325,7 +359,10 @@ def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
 
     if dbvendor != "postgres":
         # check table name mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             id = row[0].split(".")
@@ -335,13 +372,19 @@ def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
                 assert row[0].upper() == row[1]
 
         # check attname mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert row[0].upper() == row[1]
 
         # check data type mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
@@ -350,7 +393,7 @@ def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
     pgrow = run_pg_query_one(pg_cursor, f"SELECT \"ORDER_NUMBER\", \"ORDER_DATE\", \"PURCHASER\", \"QUANTITY\", \"PRODUCT_ID\" FROM \"{dbname}\".\"ORDERS\" WHERE \"ORDER_NUMBER\" = 10003")
     extrow = run_remote_query(dbvendor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM orders WHERE order_number = 10003")
     assert int(pgrow[0]) == int(extrow[0][0])
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%d-%b-%y')
     elif dbvendor == "postgres":
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%Y-%m-%d %H:%M:%S')
@@ -384,8 +427,8 @@ def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
-        time.sleep(30)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(50)
     else:
         time.sleep(10)
 
@@ -399,6 +442,7 @@ def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
     update_guc_conf(pg_cursor, "synchdb.letter_casing_strategy", "'lowercase'", True)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     time.sleep(10)
+
 
 def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_fdwsnap_upper"
@@ -433,7 +477,7 @@ def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -456,7 +500,10 @@ def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
     assert int(pgrowcount[0]) == int(extrowcount[0][0])
 
     # check table name mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         id = row[0].split(".")
@@ -466,13 +513,19 @@ def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
             assert row[0].upper() == row[1]
 
     # check attname mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert row[0].upper() == row[1]
 
     # check data type mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
@@ -481,7 +534,7 @@ def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
     pgrow = run_pg_query_one(pg_cursor, f"SELECT \"ORDER_NUMBER\", \"ORDER_DATE\", \"PURCHASER\", \"QUANTITY\", \"PRODUCT_ID\" FROM \"{dbname}\".\"ORDERS\" WHERE \"ORDER_NUMBER\" = 10003")
     extrow = run_remote_query(dbvendor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM orders WHERE order_number = 10003")
     assert int(pgrow[0]) == int(extrow[0][0])
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%d-%b-%y')
     elif dbvendor == "postgres":
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%Y-%m-%d %H:%M:%S')
@@ -515,8 +568,8 @@ def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
-        time.sleep(30)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(50)
     else:
         time.sleep(10)
 
@@ -531,6 +584,7 @@ def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
     update_guc_conf(pg_cursor, "synchdb.letter_casing_strategy", "'lowercase'", True)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     time.sleep(10)
+
 
 def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbzsnap_asis"
@@ -547,7 +601,7 @@ def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -565,7 +619,7 @@ def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
     assert int(pgtblcount[0]) == int(exttblcount[0][0])
 
     # check row counts or orders table
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         pgrowcount = run_pg_query_one(pg_cursor, f"SELECT count(*) FROM \"{dbname}\".\"ORDERS\"")
     else:
         pgrowcount = run_pg_query_one(pg_cursor, f"SELECT count(*) FROM \"{dbname}\".\"orders\"")
@@ -574,7 +628,10 @@ def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
 
     if dbvendor != "postgres":
         # check table name mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             id = row[0].split(".")
@@ -584,25 +641,31 @@ def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
                 assert row[0] == row[1]
 
         # check attname mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert row[0] == row[1]
 
         # check data type mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
 
     # check data consistency of orders table
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         pgrow = run_pg_query_one(pg_cursor, f"SELECT \"ORDER_NUMBER\", \"ORDER_DATE\", \"PURCHASER\", \"QUANTITY\", \"PRODUCT_ID\" FROM \"{dbname}\".\"ORDERS\" WHERE \"ORDER_NUMBER\" = 10003")
     else:
         pgrow = run_pg_query_one(pg_cursor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM \"{dbname}\".orders WHERE order_number = 10003")
     extrow = run_remote_query(dbvendor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM orders WHERE order_number = 10003")
     assert int(pgrow[0]) == int(extrow[0][0])
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%d-%b-%y')
     elif dbvendor == "postgres":
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%Y-%m-%d %H:%M:%S')
@@ -636,12 +699,12 @@ def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         pgrow = run_pg_query_one(pg_cursor, f"SELECT \"ORDER_NUMBER\", \"ORDER_DATE\", \"PURCHASER\", \"QUANTITY\", \"PRODUCT_ID\" FROM \"{dbname}\".\"ORDERS\" WHERE \"ORDER_NUMBER\" >= 10005")
     else:
         pgrow = run_pg_query_one(pg_cursor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM \"{dbname}\".orders WHERE order_number >= 10005")
@@ -654,6 +717,7 @@ def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
     update_guc_conf(pg_cursor, "synchdb.letter_casing_strategy", "'lowercase'", True)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     time.sleep(10)
+
 
 def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_fdwsnap_asis"
@@ -688,7 +752,7 @@ def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -706,7 +770,7 @@ def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
     assert int(pgtblcount[0]) == int(exttblcount[0][0])
 
     # check row counts or orders table
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         pgrowcount = run_pg_query_one(pg_cursor, f"SELECT count(*) FROM \"{dbname}\".\"ORDERS\"")
     else:
         pgrowcount = run_pg_query_one(pg_cursor, f"SELECT count(*) FROM \"{dbname}\".\"orders\"")
@@ -714,7 +778,10 @@ def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
     assert int(pgrowcount[0]) == int(extrowcount[0][0])
 
     # check table name mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         id = row[0].split(".")
@@ -724,25 +791,31 @@ def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
             assert row[0] == row[1]
 
     # check attname mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert row[0] == row[1]
 
     # check data type mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
 
     # check data consistency of orders table
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         pgrow = run_pg_query_one(pg_cursor, f"SELECT \"ORDER_NUMBER\", \"ORDER_DATE\", \"PURCHASER\", \"QUANTITY\", \"PRODUCT_ID\" FROM \"{dbname}\".\"ORDERS\" WHERE \"ORDER_NUMBER\" = 10003")
     else:
         pgrow = run_pg_query_one(pg_cursor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM \"{dbname}\".orders WHERE order_number = 10003")
     extrow = run_remote_query(dbvendor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM orders WHERE order_number = 10003")
     assert int(pgrow[0]) == int(extrow[0][0])
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%d-%b-%y')
     elif dbvendor == "postgres":
         assert pgrow[1] == datetime.strptime(extrow[0][1], '%Y-%m-%d %H:%M:%S')
@@ -777,12 +850,12 @@ def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         pgrow = run_pg_query_one(pg_cursor, f"SELECT \"ORDER_NUMBER\", \"ORDER_DATE\", \"PURCHASER\", \"QUANTITY\", \"PRODUCT_ID\" FROM \"{dbname}\".\"ORDERS\" WHERE \"ORDER_NUMBER\" >= 10005")
     else:
         pgrow = run_pg_query_one(pg_cursor, f"SELECT order_number, order_date, purchaser, quantity, product_id FROM \"{dbname}\".orders WHERE order_number >= 10005")
@@ -797,6 +870,7 @@ def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
     drop_repslot_and_pub(dbvendor, name, "postgres")
     time.sleep(10)
 
+
 def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbz_schemasync"
     dbname = getDbname(dbvendor).lower()
@@ -810,7 +884,7 @@ def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "schemasync")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -829,7 +903,10 @@ def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
 
     if dbvendor != "postgres":
         # check table name mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             id = row[0].split(".")
@@ -839,13 +916,19 @@ def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
                 assert row[0].lower() == row[1]
 
         # check attname mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:   
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert row[0].lower() == row[1]
 
         # check data type mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
@@ -857,7 +940,10 @@ def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
     # check state = paused
     row = run_pg_query_one(pg_cursor, f"SELECT name, connector_type, pid, stage, state, err FROM synchdb_state_view WHERE name = '{name}'")
     assert row[0] == name
-    assert row[1] == dbvendor
+    if dbvendor == "oracle23ai":
+        assert row[1] == "oracle"
+    else:
+        assert row[1] == dbvendor
     assert int(row[2]) > 0
     assert row[3] == "schema sync" or row[3] == "change data capture"
     assert row[4] == "paused"
@@ -891,7 +977,7 @@ def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -904,6 +990,7 @@ def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
     run_remote_query(dbvendor, f"DELETE FROM orders WHERE order_number > 10004")
     drop_repslot_and_pub(dbvendor, name, "postgres")
     time.sleep(10)
+
 
 def test_ConnectorStartSchemaSyncModeFDW(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_fdw_schemasync"
@@ -937,7 +1024,7 @@ def test_ConnectorStartSchemaSyncModeFDW(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "schemasync")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -955,7 +1042,10 @@ def test_ConnectorStartSchemaSyncModeFDW(pg_cursor, dbvendor):
     assert int(pgtblcount[0]) == int(exttblcount[0][0])
 
     # check table name mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         id = row[0].split(".")
@@ -965,13 +1055,19 @@ def test_ConnectorStartSchemaSyncModeFDW(pg_cursor, dbvendor):
             assert row[0].lower() == row[1]
 
     # check attname mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert row[0].lower() == row[1]
 
     # check data type mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
@@ -983,7 +1079,10 @@ def test_ConnectorStartSchemaSyncModeFDW(pg_cursor, dbvendor):
     # check state = paused
     row = run_pg_query_one(pg_cursor, f"SELECT name, connector_type, pid, stage, state, err FROM synchdb_state_view WHERE name = '{name}'")
     assert row[0] == name
-    assert row[1] == dbvendor
+    if dbvendor == "oracle23ai":
+        assert row[1] == "oracle"
+    else:
+        assert row[1] == dbvendor
     assert int(row[2]) > 0
     assert row[3] == "schema sync" or row[3] == "change data capture"
     assert row[4] == "paused"
@@ -991,7 +1090,7 @@ def test_ConnectorStartSchemaSyncModeFDW(pg_cursor, dbvendor):
 
     run_pg_query_one(pg_cursor, f"SELECT synchdb_resume_engine('{name}')")
 
-    time.sleep(10)
+    time.sleep(20)
     # test a bit of cdc
     if dbvendor == "postgres" or dbvendor == "mysql":
         query = """
@@ -1006,7 +1105,7 @@ def test_ConnectorStartSchemaSyncModeFDW(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -1021,6 +1120,7 @@ def test_ConnectorStartSchemaSyncModeFDW(pg_cursor, dbvendor):
     drop_repslot_and_pub(dbvendor, name, "postgres")
     time.sleep(10)
 
+
 def test_ConnectorStartAlwaysModeDBZ(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbz_always"
     dbname = getDbname(dbvendor).lower()
@@ -1034,7 +1134,7 @@ def test_ConnectorStartAlwaysModeDBZ(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "always")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -1053,7 +1153,10 @@ def test_ConnectorStartAlwaysModeDBZ(pg_cursor, dbvendor):
 
     if dbvendor != "postgres":
         # check table name mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             id = row[0].split(".")
@@ -1063,13 +1166,19 @@ def test_ConnectorStartAlwaysModeDBZ(pg_cursor, dbvendor):
                 assert row[0].lower() == row[1]
 
         # check attname mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert row[0].lower() == row[1]
 
         # check data type mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
@@ -1080,7 +1189,10 @@ def test_ConnectorStartAlwaysModeDBZ(pg_cursor, dbvendor):
     
     row = run_pg_query_one(pg_cursor, f"SELECT name, connector_type, pid, stage, state, err FROM synchdb_state_view WHERE name = '{name}'")
     assert row[0] == name
-    assert row[1] == dbvendor
+    if dbvendor == "oracle23ai":
+        assert row[1] == "oracle"
+    else:
+        assert row[1] == dbvendor
     assert int(row[2]) > 0
     assert row[3] == "initial snapshot" or row[3] == "change data capture"
     assert row[4] == "polling"
@@ -1089,6 +1201,7 @@ def test_ConnectorStartAlwaysModeDBZ(pg_cursor, dbvendor):
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
+
 
 def test_ConnectorStartAlwaysModeFDW(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbz_always"
@@ -1122,7 +1235,7 @@ def test_ConnectorStartAlwaysModeFDW(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "always")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -1140,7 +1253,10 @@ def test_ConnectorStartAlwaysModeFDW(pg_cursor, dbvendor):
     assert int(pgtblcount[0]) == int(exttblcount[0][0])
 
     # check table name mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         id = row[0].split(".")
@@ -1150,13 +1266,19 @@ def test_ConnectorStartAlwaysModeFDW(pg_cursor, dbvendor):
             assert row[0].lower() == row[1]
 
     # check attname mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert row[0].lower() == row[1]
 
     # check data type mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
@@ -1167,7 +1289,10 @@ def test_ConnectorStartAlwaysModeFDW(pg_cursor, dbvendor):
 
     row = run_pg_query_one(pg_cursor, f"SELECT name, connector_type, pid, stage, state, err FROM synchdb_state_view WHERE name = '{name}'")
     assert row[0] == name
-    assert row[1] == dbvendor
+    if dbvendor == "oracle23ai":
+        assert row[1] == "oracle"
+    else:
+        assert row[1] == dbvendor
     assert int(row[2]) > 0
     assert row[3] == "initial snapshot" or row[3] == "change data capture"
     assert row[4] == "polling"
@@ -1177,6 +1302,7 @@ def test_ConnectorStartAlwaysModeFDW(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     update_guc_conf(pg_cursor, "synchdb.snapshot_engine", "'debezium'", True)
     drop_repslot_and_pub(dbvendor, name, "postgres")
+
 
 def test_ConnectorStartNodataModeDBZ(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbz_nodata"
@@ -1191,7 +1317,7 @@ def test_ConnectorStartNodataModeDBZ(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "no_data")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -1210,7 +1336,10 @@ def test_ConnectorStartNodataModeDBZ(pg_cursor, dbvendor):
 
     if dbvendor != "postgres":
         # check table name mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             id = row[0].split(".")
@@ -1220,13 +1349,19 @@ def test_ConnectorStartNodataModeDBZ(pg_cursor, dbvendor):
                 assert row[0].lower() == row[1]
 
         # check attname mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert row[0].lower() == row[1]
 
         # check data type mappings
-        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+        if dbvendor == "oracle23ai":
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+        else:
+            rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
         assert len(rows) > 0
         for row in rows:
             assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
@@ -1237,7 +1372,10 @@ def test_ConnectorStartNodataModeDBZ(pg_cursor, dbvendor):
 
     row = run_pg_query_one(pg_cursor, f"SELECT name, connector_type, pid, stage, state, err FROM synchdb_state_view WHERE name = '{name}'")
     assert row[0] == name
-    assert row[1] == dbvendor
+    if dbvendor == "oracle23ai":
+        assert row[1] == "oracle"
+    else:
+        assert row[1] == dbvendor
     assert int(row[2]) > 0
     assert row[3] == "initial snapshot" or row[3] == "change data capture"
     assert row[4] == "polling"
@@ -1246,6 +1384,7 @@ def test_ConnectorStartNodataModeDBZ(pg_cursor, dbvendor):
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
+
 
 def test_ConnectorStartNodataModeFDW(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbz_nodata"
@@ -1279,7 +1418,7 @@ def test_ConnectorStartNodataModeFDW(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "no_data")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -1297,7 +1436,10 @@ def test_ConnectorStartNodataModeFDW(pg_cursor, dbvendor):
     assert int(pgtblcount[0]) == int(exttblcount[0][0])
 
     # check table name mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_tbname, pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         id = row[0].split(".")
@@ -1307,13 +1449,19 @@ def test_ConnectorStartNodataModeFDW(pg_cursor, dbvendor):
             assert row[0].lower() == row[1]
 
     # check attname mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert row[0].lower() == row[1]
 
     # check data type mappings
-    rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
+    if dbvendor == "oracle23ai":
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = 'oracle'")
+    else:
+        rows = run_pg_query(pg_cursor, f"SELECT ext_atttypename, pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND type = '{dbvendor}'")
     assert len(rows) > 0
     for row in rows:
         assert verify_default_type_mappings(row[0], row[1], dbvendor) == True
@@ -1324,7 +1472,10 @@ def test_ConnectorStartNodataModeFDW(pg_cursor, dbvendor):
 
     row = run_pg_query_one(pg_cursor, f"SELECT name, connector_type, pid, stage, state, err FROM synchdb_state_view WHERE name = '{name}'")
     assert row[0] == name
-    assert row[1] == dbvendor
+    if dbvendor == "oracle23ai":
+        assert row[1] == "oracle"
+    else:
+        assert row[1] == dbvendor
     assert int(row[2]) > 0
     assert row[3] == "initial snapshot" or row[3] == "change data capture"
     assert row[4] == "polling"
@@ -1334,6 +1485,7 @@ def test_ConnectorStartNodataModeFDW(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     update_guc_conf(pg_cursor, "synchdb.snapshot_engine", "'debezium'", True)
     drop_repslot_and_pub(dbvendor, name, "postgres")
+
 
 def test_ConnectorRestart(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor)
@@ -1347,14 +1499,17 @@ def test_ConnectorRestart(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "no_data")
     assert result == 0
 
-    if dbvendor == "oracle":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(10)
     else:
         time.sleep(5)
 
     row = run_pg_query_one(pg_cursor, f"SELECT name, connector_type, pid, stage, state, err FROM synchdb_state_view WHERE name = '{name}'")
     assert row[0] == name
-    assert row[1] == dbvendor
+    if dbvendor == "oracle23ai":
+        assert row[1] == "oracle"
+    else:
+        assert row[1] == dbvendor
     oldpid = row[2]
     assert row[2] > -1
     assert row[3] == "initial snapshot" or row[3] == "change data capture"
@@ -1364,14 +1519,17 @@ def test_ConnectorRestart(pg_cursor, dbvendor):
     row = run_pg_query_one(pg_cursor, f"SELECT synchdb_restart_connector('{name}', 'initial')")
     assert row[0] == 0
 
-    if dbvendor == "oracle":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(10)
     else:
         time.sleep(5)
 
     row = run_pg_query_one(pg_cursor, f"SELECT name, connector_type, pid, stage, state, err FROM synchdb_state_view WHERE name = '{name}'")
     assert row[0] == name
-    assert row[1] == dbvendor
+    if dbvendor == "oracle23ai":
+        assert row[1] == "oracle"
+    else:
+        assert row[1] == dbvendor
     oldpid = row[2]
     assert row[2] == oldpid
     assert row[3] == "initial snapshot" or row[3] == "change data capture"
@@ -1384,6 +1542,7 @@ def test_ConnectorRestart(pg_cursor, dbvendor):
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
+
 
 def test_ConnectorStop(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor)
@@ -1408,13 +1567,17 @@ def test_ConnectorStop(pg_cursor, dbvendor):
     time.sleep(5)
     row = run_pg_query_one(pg_cursor, f"SELECT name, connector_type, pid, stage, state, err FROM synchdb_state_view WHERE name = '{name}'")
     assert row[0] == name
-    assert row[1] == dbvendor
+    if dbvendor == "oracle23ai":
+        assert row[1] == "oracle"
+    else:
+        assert row[1] == dbvendor
     assert row[2] == -1
     assert row[4] == "stopped"
 
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
+
 
 def test_ConnectorDelete(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor)

--- a/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
+++ b/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
@@ -1,7 +1,7 @@
 import common
 import time
 from datetime import datetime
-from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, verify_default_type_mappings, stop_and_delete_synchdb_connector, drop_default_pg_schema, create_and_start_synchdb_connector, update_guc_conf, getSchema, drop_repslot_and_pub
+from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, verify_default_type_mappings, stop_and_delete_synchdb_connector, drop_default_pg_schema, create_and_start_synchdb_connector, update_guc_conf, getSchema, drop_repslot_and_pub, restart_remote_db
 
 # import pytest
 # pytestmark = pytest.mark.skip(reason="跳过此文件")
@@ -218,12 +218,13 @@ def test_InitialSnapshotFDW(pg_cursor, dbvendor):
             return
 
     update_guc_conf(pg_cursor, "synchdb.snapshot_engine", "'fdw'", True)
+    update_guc_conf(pg_cursor, "synchdb.letter_casing_strategy", "'lowercase'", True)
 
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
     if dbvendor in ("oracle", "oracle23ai", "olr"):
-        time.sleep(30)
+        time.sleep(80)
     else:
         time.sleep(10)
 
@@ -407,7 +408,7 @@ def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
     if dbvendor == "mysql":
         query = """
             INSERT INTO orders(order_number, order_date, purchaser, quantity,
-            product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102)
+            product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
         """
     elif dbvendor == "sqlserver":
         query = """
@@ -415,10 +416,10 @@ def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
             ("2025-12-12", 1002, 10000, 102)
         """
     elif dbvendor == "postgres":
-	    query = """
-		    INSERT INTO orders(order_number, order_date, purchaser, quantity,
-    		product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
-	    """
+        query = """
+            INSERT INTO orders(order_number, order_date, purchaser, quantity,
+            product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
+        """
     else:
         query = """
             INSERT INTO orders(order_number, order_date, purchaser, quantity,
@@ -478,7 +479,7 @@ def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
     assert result == 0
 
     if dbvendor in ("oracle", "oracle23ai", "olr"):
-        time.sleep(30)
+        time.sleep(80)
     else:
         time.sleep(10)
 
@@ -556,10 +557,10 @@ def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
             ("2025-12-12", 1002, 10000, 102)
         """
     elif dbvendor == "postgres":
-	    query = """
-    		INSERT INTO orders(order_number, order_date, purchaser, quantity,
-		    product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
-	    """
+        query = """
+            INSERT INTO orders(order_number, order_date, purchaser, quantity,
+            product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
+        """
     else:
         query = """
             INSERT INTO orders(order_number, order_date, purchaser, quantity,
@@ -587,6 +588,8 @@ def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
 
 
 def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
+    restart_remote_db(dbvendor)
+    
     name = getConnectorName(dbvendor) + "_dbzsnap_asis"
     dbname = getDbname(dbvendor)
     schema = getSchema(dbvendor)
@@ -687,10 +690,10 @@ def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
             ("2025-12-12", 1002, 10000, 102)
         """
     elif dbvendor == "postgres":
-    	query = """
-	    	INSERT INTO orders(order_number, order_date, purchaser, quantity,
-		    product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
-    	"""
+        query = """
+            INSERT INTO orders(order_number, order_date, purchaser, quantity,
+            product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
+        """
     else:
         query = """
             INSERT INTO orders(order_number, order_date, purchaser, quantity,
@@ -700,7 +703,7 @@ def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
 
     run_remote_query(dbvendor, query)
     if dbvendor in ("oracle", "oracle23ai", "olr"):
-        time.sleep(30)
+        time.sleep(50)
     else:
         time.sleep(10)
 
@@ -838,10 +841,10 @@ def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
             ("2025-12-12", 1002, 10000, 102)
         """
     elif dbvendor == "postgres":
-    	query = """
-		    INSERT INTO orders(order_number, order_date, purchaser, quantity,
-		    product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
-	    """
+        query = """
+            INSERT INTO orders(order_number, order_date, purchaser, quantity,
+            product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
+        """
     else:
         query = """
             INSERT INTO orders(order_number, order_date, purchaser, quantity,
@@ -851,7 +854,7 @@ def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
 
     run_remote_query(dbvendor, query)
     if dbvendor in ("oracle", "oracle23ai", "olr"):
-        time.sleep(30)
+        time.sleep(60)
     else:
         time.sleep(10)
 
@@ -869,7 +872,6 @@ def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
     update_guc_conf(pg_cursor, "synchdb.letter_casing_strategy", "'lowercase'", True)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     time.sleep(10)
-
 
 def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbz_schemasync"
@@ -965,10 +967,10 @@ def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
             1002, 10000, 102);
         """
     elif dbvendor == "postgres":
-	    query = """
-    		INSERT INTO orders(order_number, order_date, purchaser, quantity,
-		    product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
-	    """
+        query = """
+            INSERT INTO orders(order_number, order_date, purchaser, quantity,
+            product_id) VALUES (10005, '2025-12-12', 1002, 10000, 102);
+        """
     else:
         query = """
             INSERT INTO orders(order_number, order_date, purchaser, quantity,
@@ -978,7 +980,7 @@ def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
 
     run_remote_query(dbvendor, query)
     if dbvendor in ("oracle", "oracle23ai", "olr"):
-        time.sleep(30)
+        time.sleep(60)
     else:
         time.sleep(10)
 
@@ -990,7 +992,6 @@ def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
     run_remote_query(dbvendor, f"DELETE FROM orders WHERE order_number > 10004")
     drop_repslot_and_pub(dbvendor, name, "postgres")
     time.sleep(10)
-
 
 def test_ConnectorStartSchemaSyncModeFDW(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_fdw_schemasync"
@@ -1202,7 +1203,6 @@ def test_ConnectorStartAlwaysModeDBZ(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
 
-
 def test_ConnectorStartAlwaysModeFDW(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbz_always"
     dbname = getDbname(dbvendor).lower()
@@ -1384,7 +1384,6 @@ def test_ConnectorStartNodataModeDBZ(pg_cursor, dbvendor):
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
-
 
 def test_ConnectorStartNodataModeFDW(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_dbz_nodata"

--- a/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
+++ b/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
@@ -322,6 +322,7 @@ def test_InitialSnapshotFDW(pg_cursor, dbvendor):
 
 
 def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
+    restart_remote_db(dbvendor)
     name = getConnectorName(dbvendor) + "_dbzsnap_upper"
     dbname = getDbname(dbvendor).upper()
     schema = getSchema(dbvendor)

--- a/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
+++ b/src/test/pytests/synchdbtests/t/test_001_initialsnapshot.py
@@ -322,7 +322,10 @@ def test_InitialSnapshotFDW(pg_cursor, dbvendor):
 
 
 def test_InitialSnapshotDBZ_uppercase(pg_cursor, dbvendor):
-    restart_remote_db(dbvendor)
+    
+    if dbvendor == "oracle23ai":
+        restart_remote_db(dbvendor)
+
     name = getConnectorName(dbvendor) + "_dbzsnap_upper"
     dbname = getDbname(dbvendor).upper()
     schema = getSchema(dbvendor)
@@ -589,7 +592,9 @@ def test_InitialSnapshotFDW_uppercase(pg_cursor, dbvendor):
 
 
 def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
-    restart_remote_db(dbvendor)
+    
+    if dbvendor == "oracle23ai":
+        restart_remote_db(dbvendor)
     
     name = getConnectorName(dbvendor) + "_dbzsnap_asis"
     dbname = getDbname(dbvendor)
@@ -703,8 +708,10 @@ def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(50)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(10)
 
@@ -724,6 +731,10 @@ def test_InitialSnapshotDBZ_asis(pg_cursor, dbvendor):
 
 
 def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
+
+    if dbvendor == "oracle23ai":
+        restart_remote_db(dbvendor)
+    
     name = getConnectorName(dbvendor) + "_fdwsnap_asis"
     dbname = getDbname(dbvendor)
     schema = getSchema(dbvendor)
@@ -854,8 +865,10 @@ def test_InitialSnapshotFDW_asis(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
-        time.sleep(60)
+    if dbvendor in ("oracle", "olr"):
+        time.sleep(50)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(10)
 
@@ -980,8 +993,10 @@ def test_ConnectorStartSchemaSyncModeDBZ(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
-        time.sleep(60)
+    if dbvendor in ("oracle", "olr"):
+        time.sleep(50)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(10)
 
@@ -1107,8 +1122,10 @@ def test_ConnectorStartSchemaSyncModeFDW(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
-        time.sleep(30)
+    if dbvendor in ("oracle", "olr"):
+        time.sleep(50)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(10)
 

--- a/src/test/pytests/synchdbtests/t/test_002_ddl.py
+++ b/src/test/pytests/synchdbtests/t/test_002_ddl.py
@@ -5,7 +5,6 @@ from common import run_pg_query, run_pg_query_one, run_remote_query, create_sync
 # import pytest
 # pytestmark = pytest.mark.skip(reason="跳过此文件")
 
-
 def test_CreateTable(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
@@ -78,7 +77,6 @@ def test_CreateTable(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     run_remote_query(dbvendor, "DROP TABLE create_table_test")
     drop_repslot_and_pub(dbvendor, name, "postgres")
-
 
 def test_CreateTableWithSpace(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -162,7 +160,6 @@ def test_CreateTableWithSpace(pg_cursor, dbvendor):
     else:
         run_remote_query(dbvendor, "DROP TABLE \"create table test\"")
 
-
 def test_CreateTableWithNoPK(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
@@ -234,7 +231,6 @@ def test_CreateTableWithNoPK(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     run_remote_query(dbvendor, "DROP TABLE create_table_nopk")
-
 
 def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -320,7 +316,6 @@ def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     run_remote_query(dbvendor, "DROP TABLE create_table_noinlinepk")
-
 
 def test_DropTable(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -411,7 +406,6 @@ def test_DropTable(pg_cursor, dbvendor):
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
-
 
 def test_DropTableWithSpace(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -510,7 +504,6 @@ def test_DropTableWithSpace(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
 
-
 def test_AlterTableAlterColumn(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
@@ -607,7 +600,6 @@ def test_AlterTableAlterColumn(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     run_remote_query(dbvendor, "DROP TABLE alter_table_alter_col")
-
 
 def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -727,7 +719,6 @@ def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
     drop_repslot_and_pub(dbvendor, name, "postgres")
     run_remote_query(dbvendor, "DROP TABLE alter_table_addpk")
     assert True
-
 
 def test_AlterTableiAddColumn(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"

--- a/src/test/pytests/synchdbtests/t/test_002_ddl.py
+++ b/src/test/pytests/synchdbtests/t/test_002_ddl.py
@@ -330,6 +330,10 @@ def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "DROP TABLE create_table_noinlinepk")
 
 def test_DropTable(pg_cursor, dbvendor):
+
+    if dbvendor == "oracle23ai":
+        restart_remote_db(dbvendor)
+
     name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
@@ -382,8 +386,10 @@ def test_DropTable(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(20)
 

--- a/src/test/pytests/synchdbtests/t/test_002_ddl.py
+++ b/src/test/pytests/synchdbtests/t/test_002_ddl.py
@@ -2,6 +2,10 @@ import common
 import time
 from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, verify_default_type_mappings, create_and_start_synchdb_connector, stop_and_delete_synchdb_connector, drop_default_pg_schema, drop_repslot_and_pub
 
+# import pytest
+# pytestmark = pytest.mark.skip(reason="跳过此文件")
+
+
 def test_CreateTable(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
@@ -14,7 +18,7 @@ def test_CreateTable(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -55,15 +59,17 @@ def test_CreateTable(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
+
+    connecotrType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view 
             WHERE name = '{name}' AND 
-            type = '{dbvendor}' 
+            type = '{connecotrType}' 
             AND pg_tbname = '{dbname}.create_table_test'
         """)
     assert len(rows) == 3
@@ -72,6 +78,7 @@ def test_CreateTable(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     run_remote_query(dbvendor, "DROP TABLE create_table_test")
     drop_repslot_and_pub(dbvendor, name, "postgres")
+
 
 def test_CreateTableWithSpace(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -85,7 +92,7 @@ def test_CreateTableWithSpace(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -126,15 +133,17 @@ def test_CreateTableWithSpace(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(90)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
+
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view 
             WHERE name = '{name}' AND 
-            type = '{dbvendor}' 
+            type = '{connectorType}' 
             AND pg_tbname = '{dbname}.create table test'
         """)
 
@@ -153,6 +162,7 @@ def test_CreateTableWithSpace(pg_cursor, dbvendor):
     else:
         run_remote_query(dbvendor, "DROP TABLE \"create table test\"")
 
+
 def test_CreateTableWithNoPK(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
@@ -165,8 +175,8 @@ def test_CreateTableWithNoPK(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
-        time.sleep(30)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(60)
     else:
         time.sleep(10)
 
@@ -206,15 +216,16 @@ def test_CreateTableWithNoPK(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
-        time.sleep(60)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(80)
     else:
-        time.sleep(20)
+        time.sleep(40)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.create_table_nopk'
         """)
     assert len(rows) == 3
@@ -223,6 +234,7 @@ def test_CreateTableWithNoPK(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     run_remote_query(dbvendor, "DROP TABLE create_table_nopk")
+
 
 def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -236,7 +248,7 @@ def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -281,15 +293,16 @@ def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
-        time.sleep(60)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(90)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.create_table_noinlinepk'
         """)
     assert len(rows) == 3
@@ -308,6 +321,7 @@ def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
     drop_repslot_and_pub(dbvendor, name, "postgres")
     run_remote_query(dbvendor, "DROP TABLE create_table_noinlinepk")
 
+
 def test_DropTable(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
@@ -320,7 +334,7 @@ def test_DropTable(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -361,30 +375,32 @@ def test_DropTable(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.drop_table_test'
         """)
     assert len(rows) == 3
 
     run_remote_query(dbvendor, "DROP TABLE drop_table_test")
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.drop_table_test'
         """)
     
@@ -395,6 +411,7 @@ def test_DropTable(pg_cursor, dbvendor):
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
+
 
 def test_DropTableWithSpace(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -408,7 +425,7 @@ def test_DropTableWithSpace(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -449,15 +466,16 @@ def test_DropTableWithSpace(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.drop with space'
         """)
     assert len(rows) == 3
@@ -471,15 +489,16 @@ def test_DropTableWithSpace(pg_cursor, dbvendor):
     else:
         run_remote_query(dbvendor, "DROP TABLE \"drop with space\"")
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.drop with space'
         """)
     
@@ -490,7 +509,8 @@ def test_DropTableWithSpace(pg_cursor, dbvendor):
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
-    
+
+
 def test_AlterTableAlterColumn(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
@@ -503,7 +523,7 @@ def test_AlterTableAlterColumn(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -544,15 +564,16 @@ def test_AlterTableAlterColumn(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.alter_table_alter_col'
         """)
     assert len(rows) == 3
@@ -567,15 +588,16 @@ def test_AlterTableAlterColumn(pg_cursor, dbvendor):
         run_remote_query(dbvendor, "ALTER TABLE alter_table_alter_col MODIFY age NUMBER(10,0)")
 
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname, ext_atttypename, pg_atttypename FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.alter_table_alter_col'
         """)
     assert len(rows) == 3
@@ -585,6 +607,7 @@ def test_AlterTableAlterColumn(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     run_remote_query(dbvendor, "DROP TABLE alter_table_alter_col")
+
 
 def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -598,7 +621,7 @@ def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -640,15 +663,16 @@ def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
-        time.sleep(60)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(80)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.alter_table_addpk'
         """)
     assert len(rows) == 3
@@ -683,7 +707,7 @@ def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
                 ADD CONSTRAINT pk_create_table_addpk PRIMARY KEY (id);
             """)
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
@@ -702,9 +726,8 @@ def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     run_remote_query(dbvendor, "DROP TABLE alter_table_addpk")
-
-
     assert True
+
 
 def test_AlterTableiAddColumn(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -718,7 +741,7 @@ def test_AlterTableiAddColumn(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -760,15 +783,16 @@ def test_AlterTableiAddColumn(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.alter_table_add_col'
         """)
     assert len(rows) == 3
@@ -797,15 +821,16 @@ def test_AlterTableiAddColumn(pg_cursor, dbvendor):
     else:
         run_remote_query(dbvendor, "ALTER TABLE alter_table_add_col ADD age NUMBER")
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname, ext_attname, pg_attname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.alter_table_add_col'
         """)
     assert len(rows) == 4
@@ -815,6 +840,7 @@ def test_AlterTableiAddColumn(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
     run_remote_query(dbvendor, "DROP TABLE alter_table_add_col")
+
 
 def test_AlterTableDropColumn(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_ddl"
@@ -828,7 +854,7 @@ def test_AlterTableDropColumn(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
@@ -869,21 +895,22 @@ def test_AlterTableDropColumn(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
-        time.sleep(60)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(80)
     else:
         time.sleep(20)
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.alter_table_drop_col'
         """)
     assert len(rows) == 3
 
     run_remote_query(dbvendor, "ALTER TABLE alter_table_drop_col DROP COLUMN created_at")
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
@@ -893,10 +920,11 @@ def test_AlterTableDropColumn(pg_cursor, dbvendor):
         """)
     assert rows[0][0] == 1
 
+    connectorType = "oracle" if dbvendor == "oracle23ai" else dbvendor
     rows = run_pg_query(pg_cursor, f"""
         SELECT ext_tbname, pg_tbname, ext_attname, pg_attname FROM synchdb_att_view
             WHERE name = '{name}' AND
-            type = '{dbvendor}'
+            type = '{connectorType}'
             AND pg_tbname = '{dbname}.alter_table_drop_col'
         """)
     assert len(rows) == 3

--- a/src/test/pytests/synchdbtests/t/test_002_ddl.py
+++ b/src/test/pytests/synchdbtests/t/test_002_ddl.py
@@ -478,8 +478,10 @@ def test_DropTableWithSpace(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(20)
 
@@ -501,8 +503,10 @@ def test_DropTableWithSpace(pg_cursor, dbvendor):
     else:
         run_remote_query(dbvendor, "DROP TABLE \"drop with space\"")
 
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(20)
 
@@ -575,8 +579,10 @@ def test_AlterTableAlterColumn(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(20)
 
@@ -599,8 +605,10 @@ def test_AlterTableAlterColumn(pg_cursor, dbvendor):
         run_remote_query(dbvendor, "ALTER TABLE alter_table_alter_col MODIFY age NUMBER(10,0)")
 
 
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(20)
 
@@ -673,8 +681,10 @@ def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(80)
+    elif dbvendor == "oracle23ai":
+        time.sleep(120)
     else:
         time.sleep(20)
 
@@ -717,8 +727,10 @@ def test_AlterTableAlterColumnAddPK(pg_cursor, dbvendor):
                 ADD CONSTRAINT pk_create_table_addpk PRIMARY KEY (id);
             """)
 
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(20)
 
@@ -792,8 +804,10 @@ def test_AlterTableiAddColumn(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(20)
 
@@ -830,8 +844,10 @@ def test_AlterTableiAddColumn(pg_cursor, dbvendor):
     else:
         run_remote_query(dbvendor, "ALTER TABLE alter_table_add_col ADD age NUMBER")
 
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(20)
 
@@ -904,8 +920,10 @@ def test_AlterTableDropColumn(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(80)
+    elif dbvendor == "oracle23ai":
+        time.sleep(120)
     else:
         time.sleep(20)
 
@@ -919,8 +937,11 @@ def test_AlterTableDropColumn(pg_cursor, dbvendor):
     assert len(rows) == 3
 
     run_remote_query(dbvendor, "ALTER TABLE alter_table_drop_col DROP COLUMN created_at")
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(20)
 

--- a/src/test/pytests/synchdbtests/t/test_002_ddl.py
+++ b/src/test/pytests/synchdbtests/t/test_002_ddl.py
@@ -1,11 +1,15 @@
 import common
 import time
-from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, verify_default_type_mappings, create_and_start_synchdb_connector, stop_and_delete_synchdb_connector, drop_default_pg_schema, drop_repslot_and_pub
+from common import restart_remote_db, run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, verify_default_type_mappings, create_and_start_synchdb_connector, stop_and_delete_synchdb_connector, drop_default_pg_schema, drop_repslot_and_pub
 
 # import pytest
 # pytestmark = pytest.mark.skip(reason="跳过此文件")
 
 def test_CreateTable(pg_cursor, dbvendor):
+
+    if dbvendor == "oracle23ai":
+        restart_remote_db(dbvendor)
+
     name = getConnectorName(dbvendor) + "_ddl"
     dbname = getDbname(dbvendor).lower()
 
@@ -58,8 +62,10 @@ def test_CreateTable(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(100)
     else:
         time.sleep(20)
 
@@ -131,8 +137,10 @@ def test_CreateTableWithSpace(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(90)
+    elif dbvendor == "oracle23ai":
+        time.sleep(120)
     else:
         time.sleep(20)
 
@@ -213,8 +221,10 @@ def test_CreateTableWithNoPK(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(80)
+    elif dbvendor == "oracle23ai":
+        time.sleep(120)
     else:
         time.sleep(40)
 
@@ -289,8 +299,10 @@ def test_CreateTableWithNotInlinePK(pg_cursor, dbvendor):
         );
         """
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(90)
+    elif dbvendor == "oracle23ai":
+        time.sleep(120)
     else:
         time.sleep(20)
 

--- a/src/test/pytests/synchdbtests/t/test_003_datatypes.py
+++ b/src/test/pytests/synchdbtests/t/test_003_datatypes.py
@@ -9,6 +9,9 @@ from binascii import unhexlify
 
 from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, verify_default_type_mappings, create_and_start_synchdb_connector, stop_and_delete_synchdb_connector, getSchema, drop_default_pg_schema, drop_repslot_and_pub, update_guc_conf
 
+# import pytest
+# pytestmark = pytest.mark.skip(reason="跳过此文件")
+
 def parse_time_with_fraction(t):
     if '.' in t:
         main, frac = t.split('.')
@@ -77,6 +80,7 @@ def parse_timedelta(s: str):
     days, _, time = s.split()
     h, m, sec = map(int, time.split(':'))
     return timedelta(days=int(days), hours=h, minutes=m, seconds=sec)
+
 
 def test_AllDefaultDataTypes(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_addt"
@@ -268,7 +272,7 @@ def test_AllDefaultDataTypes(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(20)
@@ -471,7 +475,7 @@ def test_AllDefaultDataTypes(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(15)
@@ -684,6 +688,7 @@ def test_AllDefaultDataTypes(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "DROP TABLE mytable")
     time.sleep(5)
 
+
 def test_TableNameMapping(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_objmap_tnm"
     dbname = getDbname(dbvendor)
@@ -695,7 +700,7 @@ def test_TableNameMapping(pg_cursor, dbvendor):
         exttable_prefix= dbname + "." + schema
         
     # create objmap of type = 'table'
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         rows = run_pg_query_one(pg_cursor, f"SELECT synchdb_add_objmap('{name}', 'table', '{exttable_prefix}.OBJMAP_SRCTABLE1', '{dbname.lower()}.objmap_dsttable1')")
         assert rows[0] == 0
         rows = run_pg_query_one(pg_cursor, f"SELECT synchdb_add_objmap('{name}', 'table', '{exttable_prefix}.OBJMAP_SRCTABLE2', 'objmap_dsttable2')")
@@ -746,13 +751,13 @@ def test_TableNameMapping(pg_cursor, dbvendor):
         result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "no_data")
         assert result == 0
     
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
     # check if tables have been copied with table names mapped correctly
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         rows = run_pg_query_one(pg_cursor, f"SELECT pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND ext_tbname = '{exttable_prefix}.OBJMAP_SRCTABLE1' LIMIT 1")
         assert rows != None and len(rows) > 0 and rows[0] == f'{dbname.lower()}.objmap_dsttable1'
         rows = run_pg_query_one(pg_cursor, f"SELECT pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND ext_tbname = '{exttable_prefix}.OBJMAP_SRCTABLE2' LIMIT 1")
@@ -784,6 +789,7 @@ def test_TableNameMapping(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "DROP TABLE objmap_srctable3")
     time.sleep(5)
 
+
 def test_ColumnNameMapping(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_objmap_cnm"
     dbname = getDbname(dbvendor)
@@ -795,7 +801,7 @@ def test_ColumnNameMapping(pg_cursor, dbvendor):
         exttable_prefix= dbname + "." + schema
 
     # create objmap of type = 'column'
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         rows = run_pg_query_one(pg_cursor, f"SELECT synchdb_add_objmap('{name}', 'column', '{exttable_prefix}.OBJMAPCOL_SRCTABLE1.A', 'pgintcol')")
         assert rows[0] == 0
         rows = run_pg_query_one(pg_cursor, f"SELECT synchdb_add_objmap('{name}', 'column', '{exttable_prefix}.OBJMAPCOL_SRCTABLE1.B', 'pgtextcol')")
@@ -831,13 +837,13 @@ def test_ColumnNameMapping(pg_cursor, dbvendor):
         result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "no_data")
         assert result == 0
     
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
     # check if tables have been copied with table names mapped correctly
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         rows = run_pg_query(pg_cursor, f"SELECT ext_attname, pg_attname FROM synchdb_att_view WHERE name = '{name}' AND ext_tbname = '{exttable_prefix}.OBJMAPCOL_SRCTABLE1'")
         assert rows != None and rows[0][1] == 'pgintcol'
         assert rows != None and rows[1][1] == 'pgtextcol'
@@ -853,6 +859,7 @@ def test_ColumnNameMapping(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "DROP TABLE objmapcol_srctable1")
     time.sleep(5)
 
+
 def test_DataTypeMapping(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_objmap_dtm"
     dbname = getDbname(dbvendor)
@@ -867,7 +874,7 @@ def test_DataTypeMapping(pg_cursor, dbvendor):
         schema = getSchema(dbvendor)
         exttable_prefix= dbname + "." + schema
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         rows = run_pg_query_one(pg_cursor, f"SELECT synchdb_add_objmap('{name}', 'datatype', '{exttable_prefix}.ORDERS.ORDER_DATE', 'text|0')")
     else:
         rows = run_pg_query_one(pg_cursor, f"SELECT synchdb_add_objmap('{name}', 'datatype', '{exttable_prefix}.orders.order_date', 'text|0')")
@@ -876,13 +883,13 @@ def test_DataTypeMapping(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
     # orders table shall have been replicated
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         rows = run_pg_query_one(pg_cursor, f"SELECT pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND ext_tbname = '{exttable_prefix}.ORDERS' AND ext_attname = 'ORDER_DATE'")
     else:
         rows = run_pg_query_one(pg_cursor, f"SELECT pg_atttypename FROM synchdb_att_view WHERE name = '{name}' AND ext_tbname = '{exttable_prefix}.orders' AND ext_attname = 'order_date'")
@@ -896,6 +903,7 @@ def test_DataTypeMapping(pg_cursor, dbvendor):
     drop_repslot_and_pub(dbvendor, name, "postgres")
     if dbvendor == "postgres":
         update_guc_conf(pg_cursor, "synchdb.snapshot_engine", "'debezium'", True)
+
 
 def test_TransformExpression(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_objmap_te"
@@ -911,7 +919,7 @@ def test_TransformExpression(pg_cursor, dbvendor):
         schema = getSchema(dbvendor)
         exttable_prefix= dbname + "." + schema
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         rows = run_pg_query_one(pg_cursor, f"SELECT synchdb_add_objmap('{name}', 'transform', '{exttable_prefix}.ORDERS.PURCHASER', '%d + 1000000')")
     else:
         rows = run_pg_query_one(pg_cursor, f"SELECT synchdb_add_objmap('{name}', 'transform', '{exttable_prefix}.orders.purchaser', '%d + 1000000')")
@@ -920,13 +928,13 @@ def test_TransformExpression(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
     # orders table shall have been replicated
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         rows = run_pg_query_one(pg_cursor, f"SELECT transform FROM synchdb_att_view WHERE name = '{name}' AND ext_tbname = '{exttable_prefix}.ORDERS' AND ext_attname = 'PURCHASER'")
     else:
         rows = run_pg_query_one(pg_cursor, f"SELECT transform FROM synchdb_att_view WHERE name = '{name}' AND ext_tbname = '{exttable_prefix}.orders' AND ext_attname = 'purchaser'")
@@ -942,6 +950,7 @@ def test_TransformExpression(pg_cursor, dbvendor):
     drop_repslot_and_pub(dbvendor, name, "postgres")
     if dbvendor == "postgres":
         update_guc_conf(pg_cursor, "synchdb.snapshot_engine", "'debezium'", True)
+
 
 def test_ReloadObjmapEntries(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_objmap_roe"
@@ -960,13 +969,13 @@ def test_ReloadObjmapEntries(pg_cursor, dbvendor):
     result = create_and_start_synchdb_connector(pg_cursor, dbvendor, name, "initial")
     assert result == 0
 
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(60)
     else:
         time.sleep(20)
 
     # default table orders table shall have been replicated
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         rows = run_pg_query_one(pg_cursor, f"SELECT pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND ext_tbname = '{exttable_prefix}.ORDERS' LIMIT 1")
         assert rows[0] == f"{dbname.lower()}.orders"
 
@@ -1047,8 +1056,8 @@ def test_ReloadObjmapEntries(pg_cursor, dbvendor):
     rows = run_pg_query_one(pg_cursor, f"SELECT synchdb_reload_objmap('{name}')")
     assert rows[0] == 0
 
-    time.sleep(40)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    time.sleep(60)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         rows = run_pg_query_one(pg_cursor, f"SELECT pg_tbname FROM synchdb_att_view WHERE name = '{name}' AND ext_tbname = '{exttable_prefix}.ORDERS' LIMIT 1")
         assert rows[0] == f"{dbname.lower()}.invoices"
         rows = run_pg_query_one(pg_cursor, f"SELECT pg_attname FROM synchdb_att_view WHERE name = '{name}' AND ext_tbname = '{exttable_prefix}.ORDERS' AND ext_attname ='ORDER_NUMBER'")
@@ -1094,7 +1103,7 @@ def test_ReloadObjmapEntries(pg_cursor, dbvendor):
             INSERT INTO orders(order_number, order_date, purchaser, quantity, product_id) VALUES
                 (10005, "2025-12-12", 1002, 10000, 102)
             """)
-    elif dbvendor == "oracle" or dbvendor == "olr":
+    elif dbvendor in ("oracle", "oracle23ai", "olr"):
         extrows = run_remote_query(dbvendor, f"""
             INSERT INTO orders(order_number, order_date, purchaser, quantity, product_id) VALUES
                 (10005, TO_DATE('2025-12-12', 'YYYY-MM-DD'), 1002, 10000, 102)
@@ -1110,8 +1119,8 @@ def test_ReloadObjmapEntries(pg_cursor, dbvendor):
                 ("2025-12-12", 1002, 10000, 102)
             """)
 
-    if dbvendor == "oracle" or dbvendor == "olr":
-        time.sleep(60)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(80)
     else:
         time.sleep(20)
         

--- a/src/test/pytests/synchdbtests/t/test_003_datatypes.py
+++ b/src/test/pytests/synchdbtests/t/test_003_datatypes.py
@@ -272,8 +272,10 @@ def test_AllDefaultDataTypes(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(30)
+    elif dbvendor == "oracle23ai":
+        time.sleep(60)
     else:
         time.sleep(20)
     
@@ -475,8 +477,10 @@ def test_AllDefaultDataTypes(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor in ("oracle", "oracle23ai", "olr"):
+    if dbvendor in ("oracle", "olr"):
         time.sleep(60)
+    elif dbvendor == "oracle23ai":
+        time.sleep(120)
     else:
         time.sleep(15)
 

--- a/src/test/pytests/synchdbtests/t/test_004_dml.py
+++ b/src/test/pytests/synchdbtests/t/test_004_dml.py
@@ -2,6 +2,10 @@ import common
 import time
 from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, create_and_start_synchdb_connector, stop_and_delete_synchdb_connector, drop_default_pg_schema, drop_repslot_and_pub
 
+# import pytest
+# pytestmark = pytest.mark.skip(reason="跳过此文件")
+
+
 def test_Insert(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_insert"
     dbname = getDbname(dbvendor).lower()
@@ -44,14 +48,14 @@ def test_Insert(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(30)
     else:
         time.sleep(10)
    
     out=run_remote_query(dbvendor, "INSERT INTO inserttable (a, b) VALUES (1, 'Hello')")
     out=run_remote_query(dbvendor, "COMMIT")
-    if dbvendor == "oracle":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         time.sleep(75)
     else:
         time.sleep(15)
@@ -71,8 +75,10 @@ def test_Insert(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
 
+
 def test_InsertWithError(pg_cursor, dbvendor):
     assert True
+
 
 def test_Update(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_update"
@@ -116,7 +122,7 @@ def test_Update(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         run_remote_query(dbvendor, "ALTER TABLE updatetable ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS")
         time.sleep(30)
     else:
@@ -127,8 +133,8 @@ def test_Update(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "UPDATE updatetable SET b = 'olleH'")
     run_remote_query(dbvendor, "COMMIT")
 
-    if dbvendor == "oracle":
-        time.sleep(75)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(90)
     else:
         time.sleep(10)
 
@@ -147,8 +153,10 @@ def test_Update(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
 
+
 def test_UpdateWithError(pg_cursor, dbvendor):
     assert True
+
 
 def test_Delete(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_delete"
@@ -192,7 +200,7 @@ def test_Delete(pg_cursor, dbvendor):
         """
 
     run_remote_query(dbvendor, query)
-    if dbvendor == "oracle" or dbvendor == "olr":
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
         run_remote_query(dbvendor, "ALTER TABLE deletetable ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS")
         time.sleep(30)
     else:
@@ -203,8 +211,8 @@ def test_Delete(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "INSERT INTO deletetable (a, b) VALUES (3, 'Pytest')")
     run_remote_query(dbvendor, "COMMIT")
 
-    if dbvendor == "oracle":
-        time.sleep(75)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(80)
     else:
         time.sleep(15)
 
@@ -219,8 +227,8 @@ def test_Delete(pg_cursor, dbvendor):
         assert str(row[1]) == str(extrow[1])
 
     run_remote_query(dbvendor, "DELETE FROM deletetable WHERE a = 2")
-    if dbvendor == "oracle":
-        time.sleep(75)
+    if dbvendor in ("oracle", "oracle23ai", "olr"):
+        time.sleep(80)
     else:
         time.sleep(15)
 
@@ -238,6 +246,7 @@ def test_Delete(pg_cursor, dbvendor):
     stop_and_delete_synchdb_connector(pg_cursor, name)
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
+
 
 def test_DeleteWithError(pg_cursor, dbvendor):
     assert True

--- a/src/test/pytests/synchdbtests/t/test_004_dml.py
+++ b/src/test/pytests/synchdbtests/t/test_004_dml.py
@@ -5,7 +5,6 @@ from common import run_pg_query, run_pg_query_one, run_remote_query, create_sync
 # import pytest
 # pytestmark = pytest.mark.skip(reason="跳过此文件")
 
-
 def test_Insert(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_insert"
     dbname = getDbname(dbvendor).lower()
@@ -75,10 +74,8 @@ def test_Insert(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
 
-
 def test_InsertWithError(pg_cursor, dbvendor):
     assert True
-
 
 def test_Update(pg_cursor, dbvendor):
     name = getConnectorName(dbvendor) + "_update"
@@ -153,7 +150,6 @@ def test_Update(pg_cursor, dbvendor):
     drop_default_pg_schema(pg_cursor, dbvendor)
     drop_repslot_and_pub(dbvendor, name, "postgres")
 
-
 def test_UpdateWithError(pg_cursor, dbvendor):
     assert True
 
@@ -212,7 +208,7 @@ def test_Delete(pg_cursor, dbvendor):
     run_remote_query(dbvendor, "COMMIT")
 
     if dbvendor in ("oracle", "oracle23ai", "olr"):
-        time.sleep(80)
+        time.sleep(90)
     else:
         time.sleep(15)
 

--- a/src/test/pytests/synchdbtests/t/test_004_dml.py
+++ b/src/test/pytests/synchdbtests/t/test_004_dml.py
@@ -1,11 +1,15 @@
 import common
 import time
-from common import run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, create_and_start_synchdb_connector, stop_and_delete_synchdb_connector, drop_default_pg_schema, drop_repslot_and_pub
+from common import restart_remote_db, run_pg_query, run_pg_query_one, run_remote_query, create_synchdb_connector, getConnectorName, getDbname, create_and_start_synchdb_connector, stop_and_delete_synchdb_connector, drop_default_pg_schema, drop_repslot_and_pub
 
 # import pytest
 # pytestmark = pytest.mark.skip(reason="跳过此文件")
 
 def test_Insert(pg_cursor, dbvendor):
+
+    if dbvendor == "oracle23ai":
+        restart_remote_db(dbvendor)
+
     name = getConnectorName(dbvendor) + "_insert"
     dbname = getDbname(dbvendor).lower()
 

--- a/synchdb--1.0.sql
+++ b/synchdb--1.0.sql
@@ -2964,7 +2964,14 @@ BEGIN
         v_ext_db := p_desired_db::text;
       END IF;
     ELSE
-      v_ext_db := v_srcdb;
+      -- Oracle/OLR CDB/PDB: srcdb may be "CDB/PDB" but Debezium emits events
+      -- keyed on the CDB name only (database.dbname); strip the PDB suffix so
+      -- ext_tbname matches the Debezium event topic.
+      IF position('/' IN v_srcdb) > 0 THEN
+        v_ext_db := split_part(v_srcdb, '/', 2);
+      ELSE
+        v_ext_db := v_srcdb;
+      END IF;
     END IF;
 
     ------------------------------------------------------------------

--- a/testenv/oracle/synchdb-oracle23ai-test-internal.yaml
+++ b/testenv/oracle/synchdb-oracle23ai-test-internal.yaml
@@ -1,0 +1,17 @@
+#
+# this yaml deploys oracle and connects it to internal
+# docker network for internal testing
+#
+
+services:
+  oracle:
+    container_name: eztest_oracle23ai
+    image: hgneon/testdb-oracle:23ai
+    networks:
+      - synchdbnet
+
+networks:
+  synchdbnet:
+    name: synchdbnet
+    driver: bridge
+    internal: true

--- a/testenv/oracle/synchdb-oracle23ai-test.yaml
+++ b/testenv/oracle/synchdb-oracle23ai-test.yaml
@@ -1,0 +1,10 @@
+#
+# this yaml deploys oracle and exposes service ports
+#
+
+services:
+  oracle:
+    container_name: eztest_oracle23ai
+    image: hgneon/testdb-oracle:23ai
+    ports:
+      - 1521:1521


### PR DESCRIPTION
close #235 #236
ref #214

#### Overview
Reuse `synchdbtest` scripts and introduce a new make target `oracle23aicheck` to support Oracle 23ai CDB/PDB testing. Since the existing target `oraclecheck` shares the `oracle` prefix, pytest scripts were updated to correctly distinguish `oracle23ai` as a separate vendor while mapping it back to `oracle` for storage lookups.

#### Fix Summary
- **`synchdb--1.0.sql`**: Fixed incorrect `ext_tbname` value stored during `oracle_fdw` snapshot. The value was incorrectly stored as `free/freepdb1.orders`; corrected to `freepdb1.orders`.

#### Change Summary
- **CI**: Added Oracle 23ai test job to `.github/workflows/synchdb-ci.yml`
- **Build & setup**:
  - `Makefile` — new `oracle23aicheck` target
  - `ci/setup-remotedbs.sh` / `ci/teardown-remotedbs.sh` — Oracle 23ai environment setup
  - `testenv/oracle/synchdb-oracle23ai-test.yaml` / `synchdb-oracle23ai-test-internal.yaml`
- **pytest scripts** — updated to support `oracle23ai` vendor across all test stages:
  - `common.py`, `conftest.py`
  - `test_001_initialsnapshot.py`
  - `test_002_ddl.py`
  - `test_003_datatypes.py`
  - `test_004_dml.py`

#### Note
* Oracle 23ai container seems to have some stability issue after running for a while, and restart can help recover it.
