### PR TITLE
FDW-based initial snapshot support X509 certificate and private key

### DIFF
--- a/src/backend/executor/replication_agent.c
+++ b/src/backend/executor/replication_agent.c
@@ -970,10 +970,14 @@ ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** conne
 			"coalesce(data->>'ispn_cache_type', 'null'), "
 			"coalesce(data->>'ispn_memory_type', 'null'), "
 			"coalesce(data->>'ispn_memory_size', 'null'), "
-			"coalesce(data->>'srcschema', 'null') "
+			"coalesce(data->>'srcschema', 'null'), "
+			"coalesce(data->>'fdw_ssl_cert', 'null'), "
+			"coalesce(data->>'fdw_ssl_key', 'null'), "
+			"coalesce(data->>'fdw_ssl_rootcert', 'null'), "
+			"coalesce(pgp_sym_decrypt((data->>'fdw_ssl_cipher')::bytea, '%s'), 'null') "
 			"FROM "
 			"synchdb_conninfo WHERE name = '%s'",
-			SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, name);
+			SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, SYNCHDB_SECRET, name);
 
 	res = spi_execute_select_one(strinfo.data, &numcols, conninfoContext);
 	if (!res)
@@ -1020,10 +1024,15 @@ ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** conne
 	strlcpy(conninfo->ispn.ispn_memory_type, TextDatumGetCString(res[34]), INFINISPAN_TYPE_SIZE);
 	conninfo->ispn.ispn_memory_size = atoi(TextDatumGetCString(res[35]));
 	strlcpy(conninfo->srcschema, TextDatumGetCString(res[36]), SYNCHDB_CONNINFO_DB_NAME_SIZE);
+	strlcpy(conninfo->fdw.ssl_cert,     TextDatumGetCString(res[37]), SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+	strlcpy(conninfo->fdw.ssl_key,      TextDatumGetCString(res[38]), SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+	strlcpy(conninfo->fdw.ssl_rootcert, TextDatumGetCString(res[39]), SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+	strlcpy(conninfo->fdw.ssl_cipher,   TextDatumGetCString(res[40]), SYNCHDB_CONNINFO_NAME_SIZE);
 
 	elog(LOG, "name=%s hostname=%s, port=%d, user=%s srcdb=%s srcschema=%s"
 			"dstdb=%s table=%s snapshottable=%s connector=%s extras(ssl_mode=%s ssl_keystore=%s "
 			"ssl_keystore_pass=%s ssl_truststore=%s ssl_truststore_pass=%s) "
+			"fdw(ssl_cert=%s ssl_key=%s ssl_rootcert=%s ssl_cipher=%s) "
 			"jmx(jmx_listenaddr=%s jmx_port=%d jmx_rmiserveraddr=%s jmx_rmiport=%d "
 			"jmx_auth=%s jmx_auth_passwdfile=%s jmx_auth_accessfile=%s jmx_ssl=%s "
 			"jmx_ssl_keystore=%s jmx_ssl_keystore_pass=%s jmx_ssl_truststore=%s "
@@ -1036,6 +1045,7 @@ ra_getConninfoByName(const char * name, ConnectionInfo * conninfo, char ** conne
 			conninfo->dstdb, conninfo->table, conninfo->snapshottable, *connector,
 			conninfo->extra.ssl_mode, conninfo->extra.ssl_keystore, conninfo->extra.ssl_keystore_pass,
 			conninfo->extra.ssl_truststore, conninfo->extra.ssl_truststore_pass,
+			conninfo->fdw.ssl_cert, conninfo->fdw.ssl_key, conninfo->fdw.ssl_rootcert, conninfo->fdw.ssl_cipher,
 			conninfo->jmx.jmx_listenaddr, conninfo->jmx.jmx_port, conninfo->jmx.jmx_rmiserveraddr,
 			conninfo->jmx.jmx_rmiport, conninfo->jmx.jmx_auth ? "true" : "false",
 			conninfo->jmx.jmx_auth_passwdfile, conninfo->jmx.jmx_auth_accessfile,

--- a/src/backend/synchdb/synchdb.c
+++ b/src/backend/synchdb/synchdb.c
@@ -74,6 +74,8 @@ PG_FUNCTION_INFO_V1(synchdb_add_objmap);
 PG_FUNCTION_INFO_V1(synchdb_reload_objmap);
 PG_FUNCTION_INFO_V1(synchdb_add_extra_conninfo);
 PG_FUNCTION_INFO_V1(synchdb_del_extra_conninfo);
+PG_FUNCTION_INFO_V1(synchdb_add_fdw_conninfo);
+PG_FUNCTION_INFO_V1(synchdb_del_fdw_conninfo);
 PG_FUNCTION_INFO_V1(synchdb_del_conninfo);
 PG_FUNCTION_INFO_V1(synchdb_del_objmap);
 PG_FUNCTION_INFO_V1(synchdb_add_jmx_conninfo);
@@ -5893,6 +5895,107 @@ synchdb_del_extra_conninfo(PG_FUNCTION_ARGS)
 			"'ssl_keystore_pass', "
 			"'ssl_truststore', "
 			"'ssl_truststore_pass'] "
+			"WHERE name = '%s'",
+			SYNCHDB_CONNINFO_TABLE,
+			NameStr(*name));
+	PG_RETURN_INT32(ra_executeCommand(strinfo.data));
+}
+
+/*
+ * synchdb_add_fdw_conninfo
+ *
+ * Stores FDW TLS certificate file paths (client cert, private key, CA/root cert)
+ * for connectors using FDW snapshot mode. These are PEM file paths consumed
+ * directly by postgres_fdw / mysql_fdw. For oracle_fdw, ssl_rootcert is the
+ * Oracle Wallet directory path. Distinct from synchdb_add_extra_conninfo which
+ * configures Java Keystore/Truststore for the Debezium connector.
+ */
+Datum
+synchdb_add_fdw_conninfo(PG_FUNCTION_ARGS)
+{
+	Name name                   = PG_GETARG_NAME(0);
+	text *ssl_cert_text         = PG_GETARG_TEXT_PP(1);
+	text *ssl_key_text          = PG_GETARG_TEXT_PP(2);
+	text *ssl_rootcert_text     = PG_GETARG_TEXT_PP(3);
+	text *ssl_cipher_text       = PG_GETARG_TEXT_PP(4);
+
+	FdwConnectionInfo fdwssl = {0};
+	StringInfoData strinfo;
+	initStringInfo(&strinfo);
+
+	if (VARSIZE(ssl_cert_text) - VARHDRSZ == 0)
+		strlcpy(fdwssl.ssl_cert, "null", SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+	else if (VARSIZE(ssl_cert_text) - VARHDRSZ > SYNCHDB_CONNINFO_KEYSTORE_SIZE)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("ssl_cert path cannot be longer than %d",
+						SYNCHDB_CONNINFO_KEYSTORE_SIZE)));
+	else
+		strlcpy(fdwssl.ssl_cert, text_to_cstring(ssl_cert_text), SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+
+	if (VARSIZE(ssl_key_text) - VARHDRSZ == 0)
+		strlcpy(fdwssl.ssl_key, "null", SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+	else if (VARSIZE(ssl_key_text) - VARHDRSZ > SYNCHDB_CONNINFO_KEYSTORE_SIZE)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("ssl_key path cannot be longer than %d",
+						SYNCHDB_CONNINFO_KEYSTORE_SIZE)));
+	else
+		strlcpy(fdwssl.ssl_key, text_to_cstring(ssl_key_text), SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+
+	if (VARSIZE(ssl_rootcert_text) - VARHDRSZ == 0)
+		strlcpy(fdwssl.ssl_rootcert, "null", SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+	else if (VARSIZE(ssl_rootcert_text) - VARHDRSZ > SYNCHDB_CONNINFO_KEYSTORE_SIZE)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("ssl_rootcert path cannot be longer than %d",
+						SYNCHDB_CONNINFO_KEYSTORE_SIZE)));
+	else
+		strlcpy(fdwssl.ssl_rootcert, text_to_cstring(ssl_rootcert_text), SYNCHDB_CONNINFO_KEYSTORE_SIZE);
+
+	if (VARSIZE(ssl_cipher_text) - VARHDRSZ == 0)
+		strlcpy(fdwssl.ssl_cipher, "null", SYNCHDB_CONNINFO_NAME_SIZE);
+	else if (VARSIZE(ssl_cipher_text) - VARHDRSZ > SYNCHDB_CONNINFO_NAME_SIZE)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("ssl_cipher cannot be longer than %d",
+						SYNCHDB_CONNINFO_NAME_SIZE)));
+	else
+		strlcpy(fdwssl.ssl_cipher, text_to_cstring(ssl_cipher_text), SYNCHDB_CONNINFO_NAME_SIZE);
+
+	appendStringInfo(&strinfo, "UPDATE %s SET data = data || json_build_object("
+			"'fdw_ssl_cert',     (CASE WHEN '%s' = 'null' THEN null ELSE '%s' END), "
+			"'fdw_ssl_key',      (CASE WHEN '%s' = 'null' THEN null ELSE '%s' END), "
+			"'fdw_ssl_rootcert', (CASE WHEN '%s' = 'null' THEN null ELSE '%s' END), "
+			"'fdw_ssl_cipher',   (CASE WHEN '%s' = 'null' THEN null ELSE pgp_sym_encrypt('%s', '%s') END))::jsonb "
+			"WHERE name = '%s'",
+			SYNCHDB_CONNINFO_TABLE,
+			fdwssl.ssl_cert, fdwssl.ssl_cert,
+			fdwssl.ssl_key, fdwssl.ssl_key,
+			fdwssl.ssl_rootcert, fdwssl.ssl_rootcert,
+			fdwssl.ssl_cipher, fdwssl.ssl_cipher, SYNCHDB_SECRET,
+			NameStr(*name));
+
+	PG_RETURN_INT32(ra_executeCommand(strinfo.data));
+}
+
+/*
+ * synchdb_del_fdw_conninfo
+ *
+ * Deletes all FDW TLS certificate paths set by synchdb_add_fdw_conninfo().
+ */
+Datum
+synchdb_del_fdw_conninfo(PG_FUNCTION_ARGS)
+{
+	Name name = PG_GETARG_NAME(0);
+	StringInfoData strinfo;
+	initStringInfo(&strinfo);
+
+	appendStringInfo(&strinfo, "UPDATE %s SET data = data - ARRAY["
+			"'fdw_ssl_cert', "
+			"'fdw_ssl_key', "
+			"'fdw_ssl_rootcert', "
+			"'fdw_ssl_cipher'] "
 			"WHERE name = '%s'",
 			SYNCHDB_CONNINFO_TABLE,
 			NameStr(*name));

--- a/src/include/synchdb/synchdb.h
+++ b/src/include/synchdb/synchdb.h
@@ -305,6 +305,21 @@ typedef struct _OLRConnectionInfo
 } OLRConnectionInfo;
 
 /**
+ * FdwConnectionInfo - TLS certificate file paths for FDW-based snapshot connections.
+ * These are raw PEM file paths consumed by postgres_fdw / mysql_fdw.
+ * For oracle_fdw, ssl_rootcert is the Oracle Wallet directory path.
+ * Distinct from ExtraConnectionInfo which holds Java Keystore/Truststore
+ * paths used by the Debezium connector via JNI.
+ */
+typedef struct _FdwConnectionInfo
+{
+	char ssl_cert[SYNCHDB_CONNINFO_KEYSTORE_SIZE];
+	char ssl_key[SYNCHDB_CONNINFO_KEYSTORE_SIZE];
+	char ssl_rootcert[SYNCHDB_CONNINFO_KEYSTORE_SIZE];
+	char ssl_cipher[SYNCHDB_CONNINFO_NAME_SIZE];
+} FdwConnectionInfo;
+
+/**
  * Infinispan settings - alternative caching mechanism for oracle connector
  */
 typedef struct _IspnInfo
@@ -360,6 +375,7 @@ typedef struct _ConnectionInfo
     ExtraConnectionInfo extra;
     JMXConnectionInfo jmx;
     OLRConnectionInfo olr;
+    FdwConnectionInfo fdw;
     IspnInfo ispn;
     SnapshotEngine snapengine;
     OffsetData offsetdata;

--- a/synchdb--1.0.sql
+++ b/synchdb--1.0.sql
@@ -208,6 +208,14 @@ CREATE OR REPLACE FUNCTION synchdb_del_extra_conninfo(name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION synchdb_add_fdw_conninfo(name, text, text, text, text) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION synchdb_del_fdw_conninfo(name) RETURNS int
+AS '$libdir/synchdb'
+LANGUAGE C IMMUTABLE STRICT;
+
 CREATE OR REPLACE FUNCTION synchdb_del_conninfo(name) RETURNS int
 AS '$libdir/synchdb'
 LANGUAGE C IMMUTABLE STRICT;
@@ -321,16 +329,21 @@ LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
 DECLARE
-	v_connector  text;      -- 'oracle' | 'olr' | 'mysql' (lowercased)
-    v_hostname   text;
-    v_port       int;
-    v_srcdb      text;   -- from data->>'srcdb'
-    v_service    text;   -- v_srcdb or Oracle PDB name
-    v_user       text;
-    v_pwd        text;   -- decrypted password
-    v_server     text;
-    v_dbserver   text;   -- oracle_fdw "dbserver" option, e.g. //host:1521/SERVICE
-    v_key        text;
+	v_connector   text;      -- 'oracle' | 'olr' | 'mysql' (lowercased)
+    v_hostname    text;
+    v_port        int;
+    v_srcdb       text;   -- from data->>'srcdb'
+    v_service     text;   -- v_srcdb or Oracle PDB name
+    v_user        text;
+    v_pwd         text;   -- decrypted password
+    v_server      text;
+    v_dbserver    text;   -- oracle_fdw "dbserver" option, e.g. //host:1521/SERVICE
+    v_key         text;
+    v_ssl_mode    text;   -- ssl_mode for postgres_fdw (from extra conninfo)
+    v_ssl_cert    text;   -- FDW client certificate file path
+    v_ssl_key     text;   -- FDW client private key file path
+    v_ssl_rootcert text;  -- FDW CA cert path; for oracle_fdw: Oracle Wallet directory
+    v_ssl_cipher  text;   -- SSL cipher list (mysql_fdw only)
 BEGIN
     ----------------------------------------------------------------------
     -- 0) Fetch connector type and ensure we have a master key
@@ -401,6 +414,17 @@ BEGIN
         RAISE EXCEPTION 'No row in synchdb_conninfo for connector name %', p_connector_name;
     END IF;
 
+    -- Fetch FDW TLS cert paths set via synchdb_add_fdw_conninfo (NULL when absent)
+    SELECT
+        NULLIF(NULLIF(data->>'ssl_mode', ''), 'null'),
+        NULLIF(data->>'fdw_ssl_cert',     'null'),
+        NULLIF(data->>'fdw_ssl_key',      'null'),
+        NULLIF(data->>'fdw_ssl_rootcert', 'null'),
+        NULLIF(pgp_sym_decrypt((data->>'fdw_ssl_cipher')::bytea, v_key), 'null')
+    INTO v_ssl_mode, v_ssl_cert, v_ssl_key, v_ssl_rootcert, v_ssl_cipher
+    FROM synchdb_conninfo
+    WHERE name = p_connector_name;
+
     IF v_hostname IS NULL OR v_hostname = '' THEN
         RAISE EXCEPTION 'synchdb_conninfo[%]: data.hostname is missing', p_connector_name;
     END IF;
@@ -437,7 +461,22 @@ BEGIN
     EXECUTE format('DROP SERVER IF EXISTS %I CASCADE', v_server);
 
 	IF v_connector IN ('oracle','olr') THEN
-	    v_dbserver := format('//%s:%s/%s', v_hostname, v_port, v_service);
+		-- oracle_fdw uses Easy Connect Plus for TLS. fdw_ssl_rootcert is treated as
+		-- the Oracle Wallet directory. fdw_ssl_cert/fdw_ssl_key have no Easy Connect
+		-- equivalent and must be imported into the Wallet beforehand via orapki.
+		IF v_ssl_rootcert IS NOT NULL THEN
+			v_dbserver := format('tcps://%s:%s/%s?wallet_location=%s&ssl_server_dn_match=yes',
+			                     v_hostname, v_port, v_service, v_ssl_rootcert);
+			IF v_ssl_cert IS NOT NULL OR v_ssl_key IS NOT NULL THEN
+				RAISE NOTICE
+					'fdw_ssl_cert/fdw_ssl_key are ignored for oracle_fdw: import them into '
+					'the Wallet at % using orapki or openssl pkcs12.',
+					v_ssl_rootcert;
+			END IF;
+		ELSE
+			v_dbserver := format('//%s:%s/%s', v_hostname, v_port, v_service);
+		END IF;
+
 		EXECUTE format(
 			'CREATE SERVER %I FOREIGN DATA WRAPPER oracle_fdw OPTIONS (dbserver %L)',
 			v_server, v_dbserver
@@ -450,9 +489,14 @@ BEGIN
 
 		RAISE NOTICE 'Created server % and user mapping for CURRENT_USER', v_server;
 	ELSIF v_connector = 'mysql' THEN
-		EXECUTE format(
-            'CREATE SERVER %I FOREIGN DATA WRAPPER mysql_fdw OPTIONS (host %L, port %L)',
-            v_server, v_hostname, v_port::text
+		EXECUTE (
+            format('CREATE SERVER %I FOREIGN DATA WRAPPER mysql_fdw OPTIONS (host %L, port %L',
+                   v_server, v_hostname, v_port::text)
+            || CASE WHEN v_ssl_cert     IS NOT NULL THEN format(', ssl_cert %L',   v_ssl_cert)     ELSE '' END
+            || CASE WHEN v_ssl_key      IS NOT NULL THEN format(', ssl_key %L',    v_ssl_key)      ELSE '' END
+            || CASE WHEN v_ssl_rootcert IS NOT NULL THEN format(', ssl_ca %L',     v_ssl_rootcert) ELSE '' END
+            || CASE WHEN v_ssl_cipher   IS NOT NULL THEN format(', ssl_cipher %L', v_ssl_cipher)   ELSE '' END
+            || ')'
         );
 
         EXECUTE format(
@@ -460,9 +504,14 @@ BEGIN
             v_server, v_user, v_pwd
         );
 	ELSIF v_connector = 'postgres' THEN
-		EXECUTE format(
-            'CREATE SERVER %I FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host %L, dbname %L, port %L)',
-            v_server, v_hostname, v_srcdb, v_port::text
+		EXECUTE (
+            format('CREATE SERVER %I FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host %L, dbname %L, port %L',
+                   v_server, v_hostname, v_srcdb, v_port::text)
+            || CASE WHEN v_ssl_mode     IS NOT NULL THEN format(', sslmode %L',     v_ssl_mode)     ELSE '' END
+            || CASE WHEN v_ssl_cert     IS NOT NULL THEN format(', sslcert %L',     v_ssl_cert)     ELSE '' END
+            || CASE WHEN v_ssl_key      IS NOT NULL THEN format(', sslkey %L',      v_ssl_key)      ELSE '' END
+            || CASE WHEN v_ssl_rootcert IS NOT NULL THEN format(', sslrootcert %L', v_ssl_rootcert) ELSE '' END
+            || ')'
         );
 
         EXECUTE format(


### PR DESCRIPTION
#78 

Overview:
Add `synchdb_add_fdw_conninfo` function to configure the FDW-based initial snapshot.
* postgres_fdw and mysql_fdw: support setting cert and key
* oracle_fdw and olr: Oracle Wallet is the only way, so re-use argument `ssl_rootcert` as `Oracle Wallet Directory`

Change summaries:

* `src/include/synchdb/synchdb.h`, `src/include/synchdb/synchdb.c`:
    add struct `FdwConnectionInfo` to store FDW extra info and corresponding getter and setter functions

* `src/backend/executor/replication_agent.c` 
    modify `ra_getConninfoByName` function to return conninfo with fdw TLS info

* `synchdb--1.0.sql`
    modify `synchdb_prepare_initial_snapshot` function, so that `oracle, olr, postgres and mysql` can be configured with TLS info