### PR TITLE
Upgrade Debezium to version 3.5.2.Final

### DIFF
--- a/src/backend/debezium/pom.xml
+++ b/src/backend/debezium/pom.xml
@@ -7,6 +7,12 @@
   <version>1.1.0</version>
   <name>dbz-engine</name>
   <url>http://maven.apache.org</url>
+  <properties>
+    <debezium.version>3.5.2.Final</debezium.version>
+    <kafka.version>4.1.2</kafka.version>
+    <jackson.version>2.19.0</jackson.version>
+    <log4j2.version>2.26.1</log4j2.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -15,109 +21,115 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.33</version>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>9.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
 	  <artifactId>connect-api</artifactId>
-	  <version>3.6.2</version>
+	  <version>${kafka.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
 	  <artifactId>connect-runtime</artifactId>
-	  <version>3.6.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.zendesk</groupId>
-	  <artifactId>mysql-binlog-connector-java</artifactId>
-	  <version>0.29.1</version>
+	  <version>${kafka.version}</version>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-api</artifactId>
-	  <version>2.6.2.Final</version>
+	  <version>${debezium.version}</version>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-embedded</artifactId>
-      <version>2.6.2.Final</version>
+      <version>${debezium.version}</version>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-connector-mysql</artifactId>
-      <version>2.6.2.Final</version>
+      <version>${debezium.version}</version>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-connector-oracle</artifactId>
-      <version>2.6.2.Final</version>
+      <version>${debezium.version}</version>
+      <exclusions>
+        <!--
+          ehcache (used only for log.mining.buffer.type=ehcache, which synchdb
+          does not use) pulls pre-release JAXB artifacts hosted only on the
+          defunct maven.java.net repository
+        -->
+        <exclusion>
+          <groupId>org.ehcache</groupId>
+          <artifactId>ehcache</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-connector-sqlserver</artifactId>
-      <version>2.6.2.Final</version>
+      <version>${debezium.version}</version>
     </dependency>
     <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-postgres</artifactId>
-        <version>2.6.2.Final</version>
+        <version>${debezium.version}</version>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-core</artifactId>
-      <version>2.6.2.Final</version>
+      <version>${debezium.version}</version>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-storage-kafka</artifactId>
-      <version>2.6.2.Final</version>
+      <version>${debezium.version}</version>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-storage-file</artifactId>
-      <version>2.6.2.Final</version>
+      <version>${debezium.version}</version>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-ddl-parser</artifactId>
-      <version>2.6.2.Final</version>
+      <version>${debezium.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.36</version>
+      <version>2.0.18</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.36</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4-runtime</artifactId>
-      <version>4.10.1</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.3</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.15.3</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.15.3</version>
+      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
   <build>
@@ -125,10 +137,9 @@
 	<plugin>
         <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.1</version> <!-- Ensure this is updated -->
+            <version>3.13.0</version>
             <configuration>
-                <source>1.8</source>
-                <target>1.8</target>
+                <release>17</release>
             </configuration>
         </plugin>
         <plugin>

--- a/src/backend/debezium/src/main/java/com/example/DebeziumRunner.java
+++ b/src/backend/debezium/src/main/java/com/example/DebeziumRunner.java
@@ -702,6 +702,17 @@ public class DebeziumRunner {
 
 				props.setProperty("tasks.max", "1");
 				props.setProperty("plugin.name", "pgoutput");
+
+				/*
+				 * restore pre-3.x startup behavior: synchdb's fdw snapshot engine
+				 * writes an offset file before the replication slot exists, which
+				 * fails Debezium 3.x's valicateLogPosition() check. trust_slot skips
+				 * the check and lets Debezium create the slot and stream from it,
+				 * as Debezium 2.6 did
+				 *
+				 * TODO: https://github.com/Hornetlabs/synchdb/issues/256
+				 */
+				props.setProperty("offset.mismatch.strategy", "trust_slot");
 				props.setProperty("slot.name", myParameters.connectorName + "_" + myParameters.dstdb + "_" + "synchdb_slot");
 				props.setProperty("publication.name", myParameters.connectorName + "_" + myParameters.dstdb + "_" + "synchdb_pub");
 	

--- a/src/backend/debezium/src/main/java/com/example/DebeziumRunner.java
+++ b/src/backend/debezium/src/main/java/com/example/DebeziumRunner.java
@@ -26,9 +26,10 @@ import java.io.FileInputStream;
 import java.io.ObjectInputStream;
 import java.io.FileOutputStream;
 import java.io.ObjectOutputStream;
-import org.apache.log4j.Logger;
-import org.apache.log4j.Level;
-import org.apache.log4j.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
@@ -37,7 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 public class DebeziumRunner {
-	private static Logger logger = Logger.getRootLogger();
+	private static Logger logger = LogManager.getRootLogger();
 	private List<String> changeEvents = new ArrayList<>();
 	private DebeziumEngine<ChangeEvent<String, String>> engine;
 	private ExecutorService executor;
@@ -385,59 +386,52 @@ public class DebeziumRunner {
 		
 		Properties props = new Properties();
 
-		/* Initialize Logging */
-		if (logger.getAppender("Console") == null)
-		{
-			ConsoleAppender consoleAppender = new ConsoleAppender();
-			consoleAppender.setName("Console");
-        	consoleAppender.setLayout(new PatternLayout("%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n"));
-        	consoleAppender.setTarget(ConsoleAppender.SYSTEM_OUT);
-        	consoleAppender.activateOptions();
-			logger.addAppender(consoleAppender);
-		}
-
+		/*
+		 * Initialize Logging: console appender and pattern are declared in
+		 * src/main/resources/log4j2.xml; only the level is set at runtime
+		 */
 		switch (myParameters.logLevel)
 		{
 			case LOG_LEVEL_ALL:
 			{
-				logger.setLevel(Level.ALL);
+				Configurator.setRootLevel(Level.ALL);
 				break;
 			}
 			case LOG_LEVEL_DEBUG:
 			{
-				logger.setLevel(Level.DEBUG);
+				Configurator.setRootLevel(Level.DEBUG);
 				break;
 			}
 			case LOG_LEVEL_INFO:
 			{
-				logger.setLevel(Level.INFO);
+				Configurator.setRootLevel(Level.INFO);
 				break;
 			}
 			case LOG_LEVEL_ERROR:
 			{
-				logger.setLevel(Level.ERROR);
+				Configurator.setRootLevel(Level.ERROR);
 				break;
 			}
 			case LOG_LEVEL_FATAL:
 			{
-				logger.setLevel(Level.FATAL);
+				Configurator.setRootLevel(Level.FATAL);
 				break;
 			}
 			case LOG_LEVEL_OFF:
 			{
-				logger.setLevel(Level.OFF);
+				Configurator.setRootLevel(Level.OFF);
 				break;
 			}
 			case LOG_LEVEL_TRACE:
 			{
-				logger.setLevel(Level.TRACE);
+				Configurator.setRootLevel(Level.TRACE);
 				break;
 			}
-			default:	
+			default:
 			case LOG_LEVEL_UNDEF:
 			case LOG_LEVEL_WARN:
 			{
-				logger.setLevel(Level.WARN);
+				Configurator.setRootLevel(Level.WARN);
 				break;
 			}
 		}
@@ -1325,16 +1319,16 @@ public class DebeziumRunner {
 	{
       switch (level)
       {
-          case LOG_LEVEL_ALL:   logger.setLevel(Level.ALL);   break;
-          case LOG_LEVEL_DEBUG: logger.setLevel(Level.DEBUG); break;
-          case LOG_LEVEL_INFO:  logger.setLevel(Level.INFO);  break;
-          case LOG_LEVEL_ERROR: logger.setLevel(Level.ERROR); break;
-          case LOG_LEVEL_FATAL: logger.setLevel(Level.FATAL); break;
-          case LOG_LEVEL_OFF:   logger.setLevel(Level.OFF);   break;
-          case LOG_LEVEL_TRACE: logger.setLevel(Level.TRACE); break;
+          case LOG_LEVEL_ALL:   Configurator.setRootLevel(Level.ALL);   break;
+          case LOG_LEVEL_DEBUG: Configurator.setRootLevel(Level.DEBUG); break;
+          case LOG_LEVEL_INFO:  Configurator.setRootLevel(Level.INFO);  break;
+          case LOG_LEVEL_ERROR: Configurator.setRootLevel(Level.ERROR); break;
+          case LOG_LEVEL_FATAL: Configurator.setRootLevel(Level.FATAL); break;
+          case LOG_LEVEL_OFF:   Configurator.setRootLevel(Level.OFF);   break;
+          case LOG_LEVEL_TRACE: Configurator.setRootLevel(Level.TRACE); break;
           default:
           case LOG_LEVEL_UNDEF:
-          case LOG_LEVEL_WARN:  logger.setLevel(Level.WARN);  break;
+          case LOG_LEVEL_WARN:  Configurator.setRootLevel(Level.WARN);  break;
       }
       logger.warn("DBZ log level changed to " + logger.getLevel());
 	}

--- a/src/backend/debezium/src/main/resources/log4j2.xml
+++ b/src/backend/debezium/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="warn">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/test/pytests/synchdbtests/t/test_003_datatypes.py
+++ b/src/test/pytests/synchdbtests/t/test_003_datatypes.py
@@ -637,7 +637,7 @@ def test_AllDefaultDataTypes(pg_cursor, dbvendor):
             assert row[27] == extrow[27]
             assert row[28] == extrow[28]
             assert row[29] == extrow[29]
-            assert row[30] == None
+            assert row[30] == extrow[30]
             assert row[31] == None
             assert row[32] == extrow[32]
             assert row[33] == extrow[33]


### PR DESCRIPTION
Change summaries:

* `src/backend/debezium/src/main/java/com/example/DebeziumRunner.java`:
    * Most of the changes are for logging
    * Debezium CDC fails when started after a postgresql_fdw-based snapshot, so set `offset.mismatch.strategy` to skip the error
* `src/backend/debezium/src/main/resources/log4j2.xml`:
    * Add log4j2 configuration file
* `src/backend/debezium/pom.xml`:
    * Update package versions
    * `mysql-connector-java` has been renamed to `mysql-connector-j`
* `src/test/pytests/synchdbtests/t/test_003_datatypes.py`:
    * The PostgreSQL connector in Debezium 3.5 now supports `tsvector`, so `row[30]` is now `'full':2 'postgresql':1 'search':4 'text':3`